### PR TITLE
Fix: Settings now reflect in UI components

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,21 +3,45 @@ import "./globals.css";
 import { Providers } from "@/components/Providers";
 import Sidebar from "@/components/Sidebar";
 import Footer from "@/components/Footer";
+import { getSettings } from "@/lib/settings";
 
-export const metadata: Metadata = {
-  title: "Milanese Family Genealogy",
-  description: "Explore the Milanese family tree and ancestry",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  try {
+    const settings = await getSettings();
+    return {
+      title: `${settings.family_name} ${settings.site_name}`,
+      description: settings.site_tagline,
+    };
+  } catch {
+    return {
+      title: "Family Genealogy",
+      description: "Explore the family tree and ancestry",
+    };
+  }
+}
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Fetch settings server-side
+  let settings;
+  try {
+    settings = await getSettings();
+  } catch (error) {
+    console.error('Failed to load settings for layout:', error);
+  }
+
   return (
     <html lang="en">
+      <head>
+        {settings?.theme_color && (
+          <style>{`:root { --theme-color: ${settings.theme_color}; }`}</style>
+        )}
+      </head>
       <body>
-        <Providers>
+        <Providers settings={settings}>
           <Sidebar />
           <main className="main-content">
             {children}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,21 @@
+'use client';
+
+import { useSettings } from './SettingsProvider';
+
 export default function Footer() {
+  const settings = useSettings();
+
   return (
     <footer className="footer">
-      <p>© {new Date().getFullYear()} Milanese Family Genealogy</p>
+      <p>© {new Date().getFullYear()} {settings.family_name} {settings.site_name}</p>
+      {settings.footer_text && (
+        <p className="text-sm text-gray-500 mt-1">{settings.footer_text}</p>
+      )}
+      {settings.admin_email && (
+        <p className="text-sm text-gray-500 mt-1">
+          Contact: <a href={`mailto:${settings.admin_email}`} className="hover:underline">{settings.admin_email}</a>
+        </p>
+      )}
     </footer>
   );
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,16 +1,25 @@
+'use client';
+
+import { useSettings } from './SettingsProvider';
+
 interface HeroProps {
   title?: string;
   subtitle?: string;
 }
 
-export default function Hero({ title = "Milanese Family", subtitle = "Genealogy Database" }: HeroProps) {
+export default function Hero({ title, subtitle }: HeroProps) {
+  const settings = useSettings();
+
+  const displayTitle = title ?? settings.family_name;
+  const displaySubtitle = subtitle ?? settings.site_tagline;
+
   return (
     <section className="hero-banner">
       <div className="text-center">
         <h1 className="banner-title">
-          <span className="gradient-text">{title}</span>
+          <span className="gradient-text">{displayTitle}</span>
         </h1>
-        <p className="banner-subtitle">{subtitle}</p>
+        <p className="banner-subtitle">{displaySubtitle}</p>
       </div>
     </section>
   );

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -4,6 +4,7 @@ import { SessionProvider } from 'next-auth/react';
 import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client/core';
 import { ApolloProvider } from '@apollo/client/react';
 import { useMemo } from 'react';
+import { SettingsProvider, SiteSettings } from './SettingsProvider';
 
 function ApolloWrapper({ children }: { children: React.ReactNode }) {
   const client = useMemo(() => {
@@ -36,10 +37,19 @@ function ApolloWrapper({ children }: { children: React.ReactNode }) {
   return <ApolloProvider client={client}>{children}</ApolloProvider>;
 }
 
-export function Providers({ children }: { children: React.ReactNode }) {
+interface ProvidersProps {
+  children: React.ReactNode;
+  settings?: SiteSettings;
+}
+
+export function Providers({ children, settings }: ProvidersProps) {
   return (
     <SessionProvider refetchOnWindowFocus={false} refetchInterval={0}>
-      <ApolloWrapper>{children}</ApolloWrapper>
+      <ApolloWrapper>
+        <SettingsProvider settings={settings}>
+          {children}
+        </SettingsProvider>
+      </ApolloWrapper>
     </SessionProvider>
   );
 }

--- a/components/SettingsProvider.tsx
+++ b/components/SettingsProvider.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { createContext, useContext, ReactNode } from 'react';
+
+export interface SiteSettings {
+  site_name: string;
+  family_name: string;
+  site_tagline: string;
+  theme_color: string;
+  logo_url: string | null;
+  require_login: boolean;
+  show_living_details: boolean;
+  living_cutoff_years: number;
+  date_format: 'MDY' | 'DMY' | 'ISO';
+  default_tree_generations: number;
+  show_coats_of_arms: boolean;
+  admin_email: string | null;
+  footer_text: string | null;
+}
+
+const DEFAULT_SETTINGS: SiteSettings = {
+  site_name: 'Family Tree',
+  family_name: 'Family',
+  site_tagline: 'Preserving our heritage',
+  theme_color: '#4F46E5',
+  logo_url: null,
+  require_login: true,
+  show_living_details: false,
+  living_cutoff_years: 100,
+  date_format: 'MDY',
+  default_tree_generations: 4,
+  show_coats_of_arms: true,
+  admin_email: null,
+  footer_text: null,
+};
+
+const SettingsContext = createContext<SiteSettings>(DEFAULT_SETTINGS);
+
+export function useSettings() {
+  return useContext(SettingsContext);
+}
+
+interface SettingsProviderProps {
+  children: ReactNode;
+  settings?: SiteSettings;
+}
+
+export function SettingsProvider({ children, settings }: SettingsProviderProps) {
+  return (
+    <SettingsContext.Provider value={settings || DEFAULT_SETTINGS}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
+import { useSettings } from './SettingsProvider';
 
 const navItems = [
   { href: '/', label: 'Dashboard', icon: '🏠' },
@@ -17,6 +18,7 @@ const navItems = [
 export default function Sidebar() {
   const pathname = usePathname();
   const { data: session, status } = useSession();
+  const settings = useSettings();
   const isAdmin = session?.user?.role === 'admin';
 
   // Don't show sidebar on login page or when not authenticated
@@ -30,9 +32,9 @@ export default function Sidebar() {
   return (
     <nav className="sidebar">
       <div className="sidebar-header">
-        <div className="logo">🌳</div>
-        <h3 className="text-xl font-semibold">Milanese Family</h3>
-        <p className="text-sm text-gray-400">Genealogy Database</p>
+        <div className="logo">{settings.logo_url ? <img src={settings.logo_url} alt="Logo" className="w-8 h-8" /> : '🌳'}</div>
+        <h3 className="text-xl font-semibold">{settings.family_name}</h3>
+        <p className="text-sm text-gray-400">{settings.site_tagline}</p>
       </div>
       <ul className="nav-links">
         {navItems.map((item) => (


### PR DESCRIPTION
Fixes #18

## Changes

- Add \SettingsProvider\ context for client-side settings access
- Update \layout.tsx\ to fetch settings server-side and pass to providers  
- Update \Sidebar\ to use \amily_name\, \site_tagline\, \logo_url\ from settings
- Update \Footer\ to use \amily_name\, \site_name\, \ooter_text\, \dmin_email- Update \Hero\ to use settings as defaults (can still be overridden per-page)
- Add dynamic metadata generation using settings
- Add CSS variable \--theme-color\ for theme customization

## Testing

1. Go to Admin > Site Settings
2. Change the Family Name or Tagline
3. Save settings
4. Refresh the page - sidebar and footer should reflect the new values