### PR TITLE
Add component tests (Issue #27)

### DIFF
--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Footer Component Tests
+ */
+import { render, screen } from '@testing-library/react';
+import Footer from '@/components/Footer';
+
+// Mock SettingsProvider
+jest.mock('@/components/SettingsProvider', () => ({
+  useSettings: jest.fn(),
+}));
+
+import { useSettings } from '@/components/SettingsProvider';
+
+const mockedUseSettings = useSettings as jest.Mock;
+
+describe('Footer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders copyright with family name and site name', () => {
+    mockedUseSettings.mockReturnValue({
+      family_name: 'Milanese',
+      site_name: 'Family Tree',
+      footer_text: null,
+      admin_email: null,
+    });
+
+    render(<Footer />);
+    
+    const currentYear = new Date().getFullYear();
+    expect(screen.getByText(`© ${currentYear} Milanese Family Tree`)).toBeInTheDocument();
+  });
+
+  it('renders footer text when provided', () => {
+    mockedUseSettings.mockReturnValue({
+      family_name: 'Test',
+      site_name: 'Tree',
+      footer_text: 'Preserving our heritage for future generations',
+      admin_email: null,
+    });
+
+    render(<Footer />);
+    
+    expect(screen.getByText('Preserving our heritage for future generations')).toBeInTheDocument();
+  });
+
+  it('does not render footer text when not provided', () => {
+    mockedUseSettings.mockReturnValue({
+      family_name: 'Test',
+      site_name: 'Tree',
+      footer_text: null,
+      admin_email: null,
+    });
+
+    render(<Footer />);
+    
+    // Only copyright should be present
+    const footerElement = screen.getByRole('contentinfo');
+    expect(footerElement.querySelectorAll('p').length).toBe(1);
+  });
+
+  it('renders admin email as mailto link when provided', () => {
+    mockedUseSettings.mockReturnValue({
+      family_name: 'Test',
+      site_name: 'Tree',
+      footer_text: null,
+      admin_email: 'admin@example.com',
+    });
+
+    render(<Footer />);
+    
+    const emailLink = screen.getByRole('link', { name: 'admin@example.com' });
+    expect(emailLink).toHaveAttribute('href', 'mailto:admin@example.com');
+  });
+
+  it('does not render admin email when not provided', () => {
+    mockedUseSettings.mockReturnValue({
+      family_name: 'Test',
+      site_name: 'Tree',
+      footer_text: null,
+      admin_email: null,
+    });
+
+    render(<Footer />);
+    
+    expect(screen.queryByText(/Contact:/)).not.toBeInTheDocument();
+  });
+
+  it('renders all elements when all settings are provided', () => {
+    mockedUseSettings.mockReturnValue({
+      family_name: 'Milanese',
+      site_name: 'Family History',
+      footer_text: 'Generations of stories',
+      admin_email: 'contact@milanese.life',
+    });
+
+    render(<Footer />);
+    
+    const currentYear = new Date().getFullYear();
+    expect(screen.getByText(`© ${currentYear} Milanese Family History`)).toBeInTheDocument();
+    expect(screen.getByText('Generations of stories')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'contact@milanese.life' })).toBeInTheDocument();
+  });
+});
+

--- a/__tests__/components/Hero.test.tsx
+++ b/__tests__/components/Hero.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Hero Component Tests
+ */
+import { render, screen } from '@testing-library/react';
+import Hero from '@/components/Hero';
+
+// Mock SettingsProvider
+jest.mock('@/components/SettingsProvider', () => ({
+  useSettings: jest.fn(),
+}));
+
+import { useSettings } from '@/components/SettingsProvider';
+
+const mockedUseSettings = useSettings as jest.Mock;
+
+describe('Hero', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseSettings.mockReturnValue({
+      family_name: 'Milanese Family',
+      site_tagline: 'Preserving our heritage',
+    });
+  });
+
+  it('renders title from settings when no prop provided', () => {
+    render(<Hero />);
+    
+    expect(screen.getByText('Milanese Family')).toBeInTheDocument();
+  });
+
+  it('renders subtitle from settings when no prop provided', () => {
+    render(<Hero />);
+    
+    expect(screen.getByText('Preserving our heritage')).toBeInTheDocument();
+  });
+
+  it('renders custom title when prop provided', () => {
+    render(<Hero title="Custom Title" />);
+    
+    expect(screen.getByText('Custom Title')).toBeInTheDocument();
+    expect(screen.queryByText('Milanese Family')).not.toBeInTheDocument();
+  });
+
+  it('renders custom subtitle when prop provided', () => {
+    render(<Hero subtitle="Custom Subtitle" />);
+    
+    expect(screen.getByText('Custom Subtitle')).toBeInTheDocument();
+    expect(screen.queryByText('Preserving our heritage')).not.toBeInTheDocument();
+  });
+
+  it('renders both custom props when both provided', () => {
+    render(<Hero title="My Title" subtitle="My Subtitle" />);
+    
+    expect(screen.getByText('My Title')).toBeInTheDocument();
+    expect(screen.getByText('My Subtitle')).toBeInTheDocument();
+  });
+
+  it('renders h1 with gradient-text class', () => {
+    render(<Hero />);
+    
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toBeInTheDocument();
+    expect(heading.querySelector('.gradient-text')).toBeInTheDocument();
+  });
+});
+

--- a/__tests__/components/Sidebar.test.tsx
+++ b/__tests__/components/Sidebar.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Sidebar Component Tests
+ */
+import { render, screen } from '@testing-library/react';
+import Sidebar from '@/components/Sidebar';
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+}));
+
+// Mock next-auth/react
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+  signOut: jest.fn(),
+}));
+
+// Mock next/link
+jest.mock('next/link', () => {
+  return function MockLink({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) {
+    return <a href={href} className={className}>{children}</a>;
+  };
+});
+
+// Mock SettingsProvider
+jest.mock('@/components/SettingsProvider', () => ({
+  useSettings: jest.fn(() => ({
+    site_name: 'Test Family Tree',
+    family_name: 'Test Family',
+    site_tagline: 'Preserving our heritage',
+    theme_color: '#4F46E5',
+    logo_url: null,
+  })),
+}));
+
+import { usePathname } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useSettings } from '@/components/SettingsProvider';
+
+const mockedUsePathname = usePathname as jest.Mock;
+const mockedUseSession = useSession as jest.Mock;
+const mockedUseSettings = useSettings as jest.Mock;
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseSettings.mockReturnValue({
+      site_name: 'Test Family Tree',
+      family_name: 'Test Family',
+      site_tagline: 'Preserving our heritage',
+      theme_color: '#4F46E5',
+      logo_url: null,
+    });
+  });
+
+  describe('when unauthenticated', () => {
+    it('returns null', () => {
+      mockedUsePathname.mockReturnValue('/');
+      mockedUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+
+      const { container } = render(<Sidebar />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('when on login page', () => {
+    it('returns null', () => {
+      mockedUsePathname.mockReturnValue('/login');
+      mockedUseSession.mockReturnValue({ 
+        data: { user: { name: 'Test', email: 'test@test.com', role: 'viewer' } }, 
+        status: 'authenticated' 
+      });
+
+      const { container } = render(<Sidebar />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('when authenticated', () => {
+    beforeEach(() => {
+      mockedUsePathname.mockReturnValue('/');
+      mockedUseSession.mockReturnValue({
+        data: { user: { name: 'Test User', email: 'test@test.com', role: 'viewer' } },
+        status: 'authenticated',
+      });
+    });
+
+    it('renders sidebar with family name from settings', () => {
+      render(<Sidebar />);
+      expect(screen.getByText('Test Family')).toBeInTheDocument();
+    });
+
+    it('renders sidebar with tagline from settings', () => {
+      render(<Sidebar />);
+      expect(screen.getByText('Preserving our heritage')).toBeInTheDocument();
+    });
+
+    it('renders all navigation items', () => {
+      render(<Sidebar />);
+      
+      expect(screen.getByText('Dashboard')).toBeInTheDocument();
+      expect(screen.getByText('Family Tree')).toBeInTheDocument();
+      expect(screen.getByText('People')).toBeInTheDocument();
+      expect(screen.getByText('Research Queue')).toBeInTheDocument();
+      expect(screen.getByText('Timeline')).toBeInTheDocument();
+      expect(screen.getByText('Coats of Arms')).toBeInTheDocument();
+      expect(screen.getByText('Search')).toBeInTheDocument();
+    });
+
+    it('marks active nav item based on pathname', () => {
+      mockedUsePathname.mockReturnValue('/tree');
+      render(<Sidebar />);
+      
+      const treeLink = screen.getByRole('link', { name: /Family Tree/i });
+      expect(treeLink).toHaveClass('active');
+    });
+
+    it('shows user name and email', () => {
+      render(<Sidebar />);
+      
+      expect(screen.getByText('Test User')).toBeInTheDocument();
+      expect(screen.getByText('test@test.com')).toBeInTheDocument();
+    });
+
+    it('shows Sign Out button', () => {
+      render(<Sidebar />);
+      expect(screen.getByText('Sign Out')).toBeInTheDocument();
+    });
+
+    it('does not show Admin link for non-admin users', () => {
+      render(<Sidebar />);
+      expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when authenticated as admin', () => {
+    beforeEach(() => {
+      mockedUsePathname.mockReturnValue('/');
+      mockedUseSession.mockReturnValue({
+        data: { user: { name: 'Admin User', email: 'admin@test.com', role: 'admin' } },
+        status: 'authenticated',
+      });
+    });
+
+    it('shows Admin link for admin users', () => {
+      render(<Sidebar />);
+      expect(screen.getByText('Admin')).toBeInTheDocument();
+    });
+
+    it('Admin link has correct href', () => {
+      render(<Sidebar />);
+      const adminLink = screen.getByRole('link', { name: /Admin/i });
+      expect(adminLink).toHaveAttribute('href', '/admin');
+    });
+  });
+
+  describe('when loading', () => {
+    it('shows loading state while session is loading', () => {
+      mockedUsePathname.mockReturnValue('/');
+      mockedUseSession.mockReturnValue({ data: null, status: 'loading' });
+
+      render(<Sidebar />);
+      
+      // Should show loading skeleton (animate-pulse div)
+      const loadingDiv = document.querySelector('.animate-pulse');
+      expect(loadingDiv).toBeInTheDocument();
+    });
+  });
+
+  describe('with custom logo', () => {
+    it('renders logo image when logo_url is set', () => {
+      mockedUsePathname.mockReturnValue('/');
+      mockedUseSession.mockReturnValue({
+        data: { user: { name: 'Test', email: 'test@test.com', role: 'viewer' } },
+        status: 'authenticated',
+      });
+      mockedUseSettings.mockReturnValue({
+        site_name: 'Test',
+        family_name: 'Test Family',
+        site_tagline: 'Test',
+        theme_color: '#000',
+        logo_url: 'https://example.com/logo.png',
+      });
+
+      render(<Sidebar />);
+      
+      const logo = screen.getByAltText('Logo');
+      expect(logo).toHaveAttribute('src', 'https://example.com/logo.png');
+    });
+  });
+});
+

--- a/__tests__/components/StatsCard.test.tsx
+++ b/__tests__/components/StatsCard.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * StatsCard Component Tests
+ */
+import { render, screen } from '@testing-library/react';
+import StatsCard from '@/components/StatsCard';
+
+describe('StatsCard', () => {
+  it('renders label and value', () => {
+    render(<StatsCard label="Total People" value={500} />);
+    
+    expect(screen.getByText('Total People')).toBeInTheDocument();
+    expect(screen.getByText('500')).toBeInTheDocument();
+  });
+
+  it('renders string value', () => {
+    render(<StatsCard label="Status" value="Active" />);
+    
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('renders icon when provided', () => {
+    render(<StatsCard label="Families" value={200} icon="👨‍👩‍👧‍👦" />);
+    
+    expect(screen.getByText('👨‍👩‍👧‍👦')).toBeInTheDocument();
+  });
+
+  it('does not render icon container when icon not provided', () => {
+    const { container } = render(<StatsCard label="Test" value={0} />);
+    
+    // Should only have stat-number and stat-label divs
+    const cardContent = container.querySelector('.stat-card');
+    expect(cardContent?.children.length).toBe(2);
+  });
+
+  it('renders with correct CSS classes', () => {
+    const { container } = render(<StatsCard label="Test" value={100} />);
+    
+    expect(container.querySelector('.card')).toBeInTheDocument();
+    expect(container.querySelector('.stat-card')).toBeInTheDocument();
+    expect(container.querySelector('.stat-number')).toBeInTheDocument();
+    expect(container.querySelector('.stat-label')).toBeInTheDocument();
+  });
+
+  it('renders zero value correctly', () => {
+    render(<StatsCard label="Empty" value={0} />);
+    
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+
+  it('renders large numbers', () => {
+    render(<StatsCard label="Big Number" value={1000000} />);
+    
+    expect(screen.getByText('1000000')).toBeInTheDocument();
+  });
+});
+

--- a/__tests__/components/TreeLink.test.tsx
+++ b/__tests__/components/TreeLink.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * TreeLink Component Tests
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import TreeLink from '@/components/TreeLink';
+
+// Mock next/link
+jest.mock('next/link', () => {
+  return function MockLink({ children, href, className, title, onClick }: { 
+    children: React.ReactNode; 
+    href: string; 
+    className?: string;
+    title?: string;
+    onClick?: (e: React.MouseEvent) => void;
+  }) {
+    return <a href={href} className={className} title={title} onClick={onClick}>{children}</a>;
+  };
+});
+
+describe('TreeLink', () => {
+  it('renders tree emoji link', () => {
+    render(<TreeLink personId="person-123" />);
+    
+    expect(screen.getByText('🌳')).toBeInTheDocument();
+  });
+
+  it('links to tree page with person and view params', () => {
+    render(<TreeLink personId="person-123" />);
+    
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/tree?person=person-123&view=ancestors');
+  });
+
+  it('has View in Tree title', () => {
+    render(<TreeLink personId="test-id" />);
+    
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('title', 'View in Tree');
+  });
+
+  it('applies custom className', () => {
+    render(<TreeLink personId="test-id" className="custom-class" />);
+    
+    const link = screen.getByRole('link');
+    expect(link.className).toContain('custom-class');
+  });
+
+  it('has default styling classes', () => {
+    render(<TreeLink personId="test-id" />);
+    
+    const link = screen.getByRole('link');
+    expect(link.className).toContain('text-gray-400');
+    expect(link.className).toContain('hover:text-green-600');
+  });
+
+  it('stops event propagation on click', () => {
+    const parentClickHandler = jest.fn();
+    
+    render(
+      <div onClick={parentClickHandler}>
+        <TreeLink personId="test-id" />
+      </div>
+    );
+    
+    const link = screen.getByRole('link');
+    fireEvent.click(link);
+    
+    expect(parentClickHandler).not.toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
Adds comprehensive tests for React components.

## New Tests Added (38 tests)

### Sidebar (13 tests)
- Authentication states (unauthenticated, loading, authenticated)
- Navigation items rendering
- Active link highlighting
- Admin link visibility based on role
- Settings integration (family name, tagline, logo)
- User info display and sign out

### Footer (6 tests)
- Copyright with family name and site name
- Conditional footer text rendering
- Admin email mailto link

### Hero (6 tests)
- Default values from settings
- Custom title/subtitle props override
- Gradient text styling

### StatsCard (7 tests)
- Label and value rendering
- Icon rendering (optional)
- CSS class structure
- Zero and large number handling

### TreeLink (6 tests)
- Link URL generation with person ID
- View in Tree title
- Custom className support
- Event propagation stopping

## Coverage
- Test count increased from 85 to 123 (+38 tests)
- Component coverage significantly improved

Closes #27