### PR TITLE
Fix branding to respect site settings (Issue #29)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,14 +24,14 @@ body {
 .sidebar {
   position: fixed; left: 0; top: 0;
   width: var(--sidebar-width); height: 100vh;
-  background: linear-gradient(180deg, #1e3d22 0%, #0f1f11 100%);
+  background: linear-gradient(180deg, var(--primary-dark) 0%, color-mix(in srgb, var(--primary-dark) 50%, black) 100%);
   color: white; display: flex; flex-direction: column;
   padding: 2rem 0; z-index: 1000;
 }
 
 .sidebar-header { text-align: center; padding: 0 1.5rem 2rem; border-bottom: 1px solid rgba(255,255,255,0.1); }
 .logo { width: 80px; height: 80px; margin: 0 auto 1rem;
-  background: linear-gradient(135deg, rgba(44,85,48,0.3), rgba(139,92,246,0.2));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--primary-color) 30%, transparent), color-mix(in srgb, var(--accent-color) 20%, transparent));
   border-radius: 50%; display: flex; align-items: center; justify-content: center;
   font-size: 2.5rem; }
 
@@ -39,7 +39,7 @@ body {
 .nav-links li { margin: 0.5rem 0; }
 .nav-link { display: block; padding: 0.75rem 1.5rem; color: rgba(255,255,255,0.7);
   text-decoration: none; border-left: 3px solid transparent; transition: all 0.3s; }
-.nav-link:hover, .nav-link.active { color: white; background: rgba(44,85,48,0.3); border-left-color: var(--primary-color); }
+.nav-link:hover, .nav-link.active { color: white; background: color-mix(in srgb, var(--primary-color) 30%, transparent); border-left-color: var(--primary-color); }
 
 /* Main Content */
 .main-content { margin-left: var(--sidebar-width); height: 100vh; display: flex; flex-direction: column; overflow: hidden; }
@@ -48,8 +48,8 @@ body {
 /* Hero */
 .hero-banner {
   min-height: 15vh; display: flex; align-items: center; justify-content: center;
-  background: linear-gradient(135deg, #1e3d22 0%, #0f1f11 100%);
-  border-bottom: 2px solid rgba(44,85,48,0.4); flex-shrink: 0;
+  background: linear-gradient(135deg, var(--primary-dark) 0%, color-mix(in srgb, var(--primary-dark) 50%, black) 100%);
+  border-bottom: 2px solid color-mix(in srgb, var(--primary-color) 40%, transparent); flex-shrink: 0;
 }
 .banner-title { font-size: 2.5rem; font-weight: 800; color: white; margin: 0; }
 .gradient-text { background: linear-gradient(135deg, #4ade80, #22c55e); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
@@ -81,7 +81,7 @@ body {
 .data-table { width: 100%; border-collapse: collapse; background: white; border-radius: 12px; overflow: hidden; }
 .data-table th { text-align: left; padding: 1rem; background: var(--bg-light); font-weight: 600; border-bottom: 2px solid #e5e7eb; }
 .data-table td { padding: 1rem; border-bottom: 1px solid #e5e7eb; }
-.data-table tr:hover { background: rgba(44,85,48,0.02); }
+.data-table tr:hover { background: color-mix(in srgb, var(--primary-color) 2%, transparent); }
 
 /* Timeline */
 .timeline { position: relative; padding-left: 2rem; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,12 +33,27 @@ export default async function RootLayout({
     console.error('Failed to load settings for layout:', error);
   }
 
+  // Generate darker shade for gradients
+  const generateDarkerColor = (hex: string): string => {
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    const darken = (c: number) => Math.max(0, Math.floor(c * 0.7));
+    return `#${darken(r).toString(16).padStart(2, '0')}${darken(g).toString(16).padStart(2, '0')}${darken(b).toString(16).padStart(2, '0')}`;
+  };
+
+  const themeColor = settings?.theme_color || '#2c5530';
+  const themeDark = generateDarkerColor(themeColor);
+
   return (
     <html lang="en">
       <head>
-        {settings?.theme_color && (
-          <style>{`:root { --theme-color: ${settings.theme_color}; }`}</style>
-        )}
+        <style>{`
+          :root {
+            --primary-color: ${themeColor};
+            --primary-dark: ${themeDark};
+          }
+        `}</style>
       </head>
       <body>
         <Providers settings={settings}>


### PR DESCRIPTION
Fixes the branding issue where theme colors from admin settings were not being applied to the UI.

## Problem
The layout was injecting a \--theme-color\ CSS variable, but the CSS used hardcoded colors (like \#1e3d22\, \gba(44,85,48,0.3)\) instead of CSS variables.

## Solution
1. **layout.tsx**: Now injects \--primary-color\ and \--primary-dark\ (auto-generated darker shade) from the theme_color setting
2. **globals.css**: Updated to use CSS variables with \color-mix()\ for transparent overlays

## Changes Applied To
- Sidebar background gradient
- Logo container gradient
- Navigation hover/active states
- Hero banner gradient
- Table row hover states

## Testing
- All 123 tests pass
- Build succeeds
- Theme color changes in admin settings now properly affect the UI

Closes #29