### PR TITLE
Collapse Notable Relatives panel by default (Issue #32)

### DIFF
--- a/components/FamilyTree.tsx
+++ b/components/FamilyTree.tsx
@@ -123,7 +123,7 @@ export default function FamilyTree({ rootPersonId, showAncestors, onPersonClick,
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
   const [priorityPopup, setPriorityPopup] = useState<PriorityPopup | null>(null);
   const [crestPopup, setCrestPopup] = useState<CrestPopup | null>(null);
-  const [notablePanelOpen, setNotablePanelOpen] = useState(true);
+  const [notablePanelOpen, setNotablePanelOpen] = useState(false);
 
   // GraphQL data fetching
   interface QueryResult {


### PR DESCRIPTION
Simple UX improvement: Notable Relatives panel is now collapsed by default in the tree view.

## Change
Changed initial state of 
otablePanelOpen from 	rue to alse.

## Rationale
- Keeps focus on the immediate family tree
- Reduces visual clutter on initial load
- Users can still expand the panel with one click

Closes #32