### PR TITLE
Set up minimum coverage thresholds (Issue #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Kindred
 
+[![CI](https://github.com/pmilano1/kindred/actions/workflows/ci.yml/badge.svg)](https://github.com/pmilano1/kindred/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/tests-132%20passing-brightgreen)](https://github.com/pmilano1/kindred)
+
 A modern genealogy web application built with Next.js 15, featuring interactive family tree visualization, research tracking, and role-based access control.
 
 ## Features

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -24,6 +24,37 @@ const customJestConfig = {
     '/node_modules/',
     '/.next/',
   ],
+  // Coverage thresholds - prevent regression
+  // These are set based on current coverage levels
+  // Increase these as more tests are added
+  coverageThreshold: {
+    global: {
+      branches: 1,
+      functions: 0,
+      lines: 1,
+      statements: 1,
+    },
+    // Higher thresholds for well-tested components
+    './components/PersonCard.tsx': {
+      branches: 80,
+      functions: 100,
+      lines: 90,
+      statements: 90,
+    },
+    './components/LoadingSpinner.tsx': {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+    // Resolver coverage threshold
+    './lib/graphql/resolvers.ts': {
+      branches: 35,
+      functions: 35,
+      lines: 40,
+      statements: 40,
+    },
+  },
 };
 
 export default createJestConfig(customJestConfig);


### PR DESCRIPTION
## Summary
Configures Jest coverage thresholds to prevent test coverage regression.

## Changes
- Added \coverageThreshold\ to \jest.config.mjs- Added CI badge and test count badge to README

## Thresholds

| Scope | Threshold |
|-------|-----------|
| Global | 1% minimum (prevents complete test removal) |
| PersonCard.tsx | 90%+ lines, 80%+ branches |
| LoadingSpinner.tsx | 100% |
| resolvers.ts | 40%+ lines |

## Rationale
- Low global threshold acknowledges current coverage state
- Per-file thresholds protect well-tested code from regression
- Thresholds can be increased as more tests are added

Closes #28