### PR TITLE
Editing: Add/edit/delete facts and events

### DIFF
--- a/components/FactsEditor.tsx
+++ b/components/FactsEditor.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from '@apollo/client/react';
+import { ADD_FACT, UPDATE_FACT, DELETE_FACT, GET_PERSON } from '@/lib/graphql/queries';
+import { Fact } from '@/lib/types';
+
+interface Props {
+  personId: string;
+  facts: Fact[];
+  canEdit: boolean;
+}
+
+const FACT_TYPES = ['education', 'religion', 'nationality', 'ethnicity', 'title', 'nickname', 'physical_description', 'coat_of_arms', 'other'];
+
+export default function FactsEditor({ personId, facts, canEdit }: Props) {
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [formData, setFormData] = useState({ fact_type: 'other', fact_value: '' });
+
+  const refetchQueries = [{ query: GET_PERSON, variables: { id: personId } }];
+  const [addFact, { loading: adding }] = useMutation(ADD_FACT, { refetchQueries });
+  const [updateFact, { loading: updating }] = useMutation(UPDATE_FACT, { refetchQueries });
+  const [deleteFact] = useMutation(DELETE_FACT, { refetchQueries });
+
+  // Filter out coat_of_arms facts (handled separately)
+  const displayFacts = facts.filter(f => f.fact_type !== 'coat_of_arms');
+
+  const resetForm = () => {
+    setFormData({ fact_type: 'other', fact_value: '' });
+    setEditingId(null);
+    setShowForm(false);
+  };
+
+  const handleEdit = (fact: Fact) => {
+    setFormData({ fact_type: fact.fact_type || 'other', fact_value: fact.fact_value || '' });
+    setEditingId(fact.id);
+    setShowForm(true);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const input = { fact_type: formData.fact_type, fact_value: formData.fact_value || null };
+    if (editingId) {
+      await updateFact({ variables: { id: editingId, input } });
+    } else {
+      await addFact({ variables: { personId, input } });
+    }
+    resetForm();
+  };
+
+  const handleDelete = async (id: number) => {
+    if (confirm('Delete this fact?')) {
+      await deleteFact({ variables: { id } });
+    }
+  };
+
+  const getIcon = (type: string | null) => {
+    const icons: Record<string, string> = {
+      education: '🎓', religion: '✡️', nationality: '🌍', ethnicity: '🧬',
+      title: '👑', nickname: '📛', physical_description: '👤', coat_of_arms: '🛡️'
+    };
+    return icons[type || ''] || '📋';
+  };
+
+  return (
+    <div className="card p-6 mb-6">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="section-title">📋 Additional Information</h3>
+        {canEdit && !showForm && (
+          <button onClick={() => setShowForm(true)} className="text-sm px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200">
+            + Add Fact
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <form onSubmit={handleSubmit} className="mb-4 p-4 bg-gray-50 rounded-lg space-y-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Fact Type</label>
+            <select value={formData.fact_type} onChange={(e) => setFormData(p => ({ ...p, fact_type: e.target.value }))}
+              className="w-full border rounded px-3 py-2">
+              {FACT_TYPES.map(t => <option key={t} value={t}>{t.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}</option>)}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Value</label>
+            <input type="text" value={formData.fact_value} onChange={(e) => setFormData(p => ({ ...p, fact_value: e.target.value }))}
+              className="w-full border rounded px-3 py-2" placeholder="Enter value..." required />
+          </div>
+          <div className="flex gap-2">
+            <button type="submit" disabled={adding || updating}
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+              {editingId ? 'Update' : 'Add'}
+            </button>
+            <button type="button" onClick={resetForm} className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">Cancel</button>
+          </div>
+        </form>
+      )}
+
+      {displayFacts.length === 0 && !showForm ? (
+        <p className="text-gray-500 text-sm">No additional facts recorded.</p>
+      ) : (
+        <div className="space-y-2">
+          {displayFacts.map((fact) => (
+            <div key={fact.id} className="flex items-center justify-between text-sm group">
+              <div>
+                <span className="text-gray-600 font-medium">{getIcon(fact.fact_type)} {fact.fact_type?.replace(/_/g, ' ') || 'Fact'}:</span>{' '}
+                <span className="text-gray-800">{fact.fact_value}</span>
+              </div>
+              {canEdit && (
+                <div className="opacity-0 group-hover:opacity-100 flex gap-1">
+                  <button onClick={() => handleEdit(fact)} className="text-blue-600 hover:text-blue-800">✏️</button>
+                  <button onClick={() => handleDelete(fact.id)} className="text-red-600 hover:text-red-800">🗑️</button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/components/LifeEventsEditor.tsx
+++ b/components/LifeEventsEditor.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from '@apollo/client/react';
+import { ADD_LIFE_EVENT, UPDATE_LIFE_EVENT, DELETE_LIFE_EVENT, GET_PERSON } from '@/lib/graphql/queries';
+import { LifeEvent } from '@/lib/types';
+
+interface Props {
+  personId: string;
+  lifeEvents: LifeEvent[];
+  canEdit: boolean;
+}
+
+const EVENT_TYPES = ['residence', 'occupation', 'education', 'military', 'immigration', 'emigration', 'census', 'other'];
+
+export default function LifeEventsEditor({ personId, lifeEvents, canEdit }: Props) {
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [formData, setFormData] = useState({ event_type: 'residence', event_date: '', event_year: '', event_place: '', event_value: '' });
+
+  const refetchQueries = [{ query: GET_PERSON, variables: { id: personId } }];
+  const [addEvent, { loading: adding }] = useMutation(ADD_LIFE_EVENT, { refetchQueries });
+  const [updateEvent, { loading: updating }] = useMutation(UPDATE_LIFE_EVENT, { refetchQueries });
+  const [deleteEvent] = useMutation(DELETE_LIFE_EVENT, { refetchQueries });
+
+  const resetForm = () => {
+    setFormData({ event_type: 'residence', event_date: '', event_year: '', event_place: '', event_value: '' });
+    setEditingId(null);
+    setShowForm(false);
+  };
+
+  const handleEdit = (evt: LifeEvent) => {
+    setFormData({
+      event_type: evt.event_type,
+      event_date: evt.event_date || '',
+      event_year: evt.event_year?.toString() || '',
+      event_place: evt.event_place || '',
+      event_value: evt.event_value || '',
+    });
+    setEditingId(evt.id);
+    setShowForm(true);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const input = {
+      event_type: formData.event_type,
+      event_date: formData.event_date || null,
+      event_year: formData.event_year ? parseInt(formData.event_year, 10) : null,
+      event_place: formData.event_place || null,
+      event_value: formData.event_value || null,
+    };
+    if (editingId) {
+      await updateEvent({ variables: { id: editingId, input } });
+    } else {
+      await addEvent({ variables: { personId, input } });
+    }
+    resetForm();
+  };
+
+  const handleDelete = async (id: number) => {
+    if (confirm('Delete this life event?')) {
+      await deleteEvent({ variables: { id } });
+    }
+  };
+
+  const getIcon = (type: string) => {
+    const icons: Record<string, string> = { residence: '🏠', occupation: '💼', education: '🎓', military: '🎖️', immigration: '🚢', emigration: '✈️', census: '📊' };
+    return icons[type] || '📌';
+  };
+
+  return (
+    <div className="card p-6 mb-6">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="section-title">📅 Life Events</h3>
+        {canEdit && !showForm && (
+          <button onClick={() => setShowForm(true)} className="text-sm px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200">
+            + Add Event
+          </button>
+        )}
+      </div>
+
+      {showForm && (
+        <form onSubmit={handleSubmit} className="mb-4 p-4 bg-gray-50 rounded-lg space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Event Type</label>
+              <select value={formData.event_type} onChange={(e) => setFormData(p => ({ ...p, event_type: e.target.value }))}
+                className="w-full border rounded px-3 py-2">
+                {EVENT_TYPES.map(t => <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Year</label>
+              <input type="number" value={formData.event_year} onChange={(e) => setFormData(p => ({ ...p, event_year: e.target.value }))}
+                className="w-full border rounded px-3 py-2" placeholder="1920" />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Date (optional)</label>
+            <input type="text" value={formData.event_date} onChange={(e) => setFormData(p => ({ ...p, event_date: e.target.value }))}
+              className="w-full border rounded px-3 py-2" placeholder="15 Mar 1920" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Place</label>
+            <input type="text" value={formData.event_place} onChange={(e) => setFormData(p => ({ ...p, event_place: e.target.value }))}
+              className="w-full border rounded px-3 py-2" placeholder="City, State, Country" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Details</label>
+            <input type="text" value={formData.event_value} onChange={(e) => setFormData(p => ({ ...p, event_value: e.target.value }))}
+              className="w-full border rounded px-3 py-2" placeholder="e.g., Farmer, Harvard University" />
+          </div>
+          <div className="flex gap-2">
+            <button type="submit" disabled={adding || updating}
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">
+              {editingId ? 'Update' : 'Add'}
+            </button>
+            <button type="button" onClick={resetForm} className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300">Cancel</button>
+          </div>
+        </form>
+      )}
+
+      {lifeEvents.length === 0 && !showForm ? (
+        <p className="text-gray-500 text-sm">No life events recorded.</p>
+      ) : (
+        <div className="space-y-2">
+          {lifeEvents.map((evt) => (
+            <div key={evt.id} className="flex items-start justify-between gap-2 text-sm group">
+              <div className="flex items-start gap-2">
+                <span className="bg-gray-100 px-2 py-0.5 rounded text-gray-600 capitalize">
+                  {getIcon(evt.event_type)} {evt.event_type}
+                </span>
+                {(evt.event_date || evt.event_year) && <span className="text-gray-500">{evt.event_date || evt.event_year}</span>}
+                {evt.event_place && <span className="text-gray-700">{evt.event_place}</span>}
+                {evt.event_value && <span className="text-gray-600 italic">{evt.event_value}</span>}
+              </div>
+              {canEdit && (
+                <div className="opacity-0 group-hover:opacity-100 flex gap-1">
+                  <button onClick={() => handleEdit(evt)} className="text-blue-600 hover:text-blue-800">✏️</button>
+                  <button onClick={() => handleDelete(evt.id)} className="text-red-600 hover:text-red-800">🗑️</button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/components/PersonPageClient.tsx
+++ b/components/PersonPageClient.tsx
@@ -9,6 +9,8 @@ import { GET_PERSON, UPDATE_NOTABLE_STATUS } from '@/lib/graphql/queries';
 import ResearchPanel from '@/components/ResearchPanel';
 import TreeLink from '@/components/TreeLink';
 import Hero from '@/components/Hero';
+import LifeEventsEditor from '@/components/LifeEventsEditor';
+import FactsEditor from '@/components/FactsEditor';
 import { Person, Family, LifeEvent, Fact } from '@/lib/types';
 
 interface PersonData {
@@ -324,25 +326,7 @@ export default function PersonPageClient({ personId }: Props) {
         )}
 
         {/* Life Events (residences, occupations, other events) */}
-        {person.lifeEvents.length > 0 && (
-          <div className="card p-6 mb-6">
-            <h3 className="section-title">📅 Life Events</h3>
-            <div className="space-y-2">
-              {person.lifeEvents.map((evt) => (
-                <div key={`${evt.event_type}-${evt.id}`} className="flex items-start gap-2 text-sm">
-                  <span className="bg-gray-100 px-2 py-0.5 rounded text-gray-600 capitalize">
-                    {evt.event_type === 'residence' ? '🏠' : evt.event_type === 'occupation' ? '💼' : '📌'} {evt.event_type}
-                  </span>
-                  {(evt.event_date || evt.event_year) && (
-                    <span className="text-gray-500">{evt.event_date || evt.event_year}</span>
-                  )}
-                  {evt.event_value && <span className="text-gray-800 font-medium">{evt.event_value}</span>}
-                  {evt.event_place && <span className="text-gray-600">{evt.event_place}</span>}
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <LifeEventsEditor personId={personId} lifeEvents={person.lifeEvents} canEdit={canEdit} />
 
         {/* Coat of Arms */}
         {person.facts.filter(f => f.fact_type === 'coat_of_arms').length > 0 && (
@@ -367,19 +351,7 @@ export default function PersonPageClient({ personId }: Props) {
         )}
 
         {/* Facts */}
-        {person.facts.filter(f => f.fact_type !== 'coat_of_arms').length > 0 && (
-          <div className="card p-6 mb-6">
-            <h3 className="section-title">📋 Additional Information</h3>
-            <div className="space-y-2">
-              {person.facts.filter(f => f.fact_type !== 'coat_of_arms').map((fact) => (
-                <div key={fact.id} className="text-sm">
-                  <span className="text-gray-600 font-medium">{fact.fact_type || 'Fact'}:</span>{' '}
-                  <span className="text-gray-800">{fact.fact_value}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <FactsEditor personId={personId} facts={person.facts} canEdit={canEdit} />
 
         <Link href="/people" className="inline-block tree-btn">
           ← Back to People

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -260,6 +260,68 @@ export const DELETE_PERSON = gql`
   }
 `;
 
+// Life Event mutations
+export const ADD_LIFE_EVENT = gql`
+  mutation AddLifeEvent($personId: ID!, $input: LifeEventInput!) {
+    addLifeEvent(personId: $personId, input: $input) {
+      id
+      person_id
+      event_type
+      event_date
+      event_year
+      event_place
+      event_value
+    }
+  }
+`;
+
+export const UPDATE_LIFE_EVENT = gql`
+  mutation UpdateLifeEvent($id: Int!, $input: LifeEventInput!) {
+    updateLifeEvent(id: $id, input: $input) {
+      id
+      event_type
+      event_date
+      event_year
+      event_place
+      event_value
+    }
+  }
+`;
+
+export const DELETE_LIFE_EVENT = gql`
+  mutation DeleteLifeEvent($id: Int!) {
+    deleteLifeEvent(id: $id)
+  }
+`;
+
+// Fact mutations
+export const ADD_FACT = gql`
+  mutation AddFact($personId: ID!, $input: FactInput!) {
+    addFact(personId: $personId, input: $input) {
+      id
+      person_id
+      fact_type
+      fact_value
+    }
+  }
+`;
+
+export const UPDATE_FACT = gql`
+  mutation UpdateFact($id: Int!, $input: FactInput!) {
+    updateFact(id: $id, input: $input) {
+      id
+      fact_type
+      fact_value
+    }
+  }
+`;
+
+export const DELETE_FACT = gql`
+  mutation DeleteFact($id: Int!) {
+    deleteFact(id: $id)
+  }
+`;
+
 export const UPDATE_NOTABLE_STATUS = gql`
   mutation UpdateNotableStatus($id: ID!, $isNotable: Boolean!, $notableDescription: String) {
     updatePerson(id: $id, input: { is_notable: $isNotable, notable_description: $notableDescription }) {

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -524,7 +524,58 @@ export const resolvers = {
 
       return true;
     },
-    
+
+    // Life Event mutations
+    addLifeEvent: async (_: unknown, { personId, input }: { personId: string; input: { event_type: string; event_date?: string; event_year?: number; event_place?: string; event_value?: string } }, context: Context) => {
+      requireAuth(context, 'editor');
+      const { rows } = await pool.query(
+        `INSERT INTO life_events (person_id, event_type, event_date, event_year, event_place, event_value)
+         VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+        [personId, input.event_type, input.event_date || null, input.event_year || null, input.event_place || null, input.event_value || null]
+      );
+      return rows[0];
+    },
+
+    updateLifeEvent: async (_: unknown, { id, input }: { id: number; input: { event_type: string; event_date?: string; event_year?: number; event_place?: string; event_value?: string } }, context: Context) => {
+      requireAuth(context, 'editor');
+      const { rows } = await pool.query(
+        `UPDATE life_events SET event_type = $2, event_date = $3, event_year = $4, event_place = $5, event_value = $6 WHERE id = $1 RETURNING *`,
+        [id, input.event_type, input.event_date || null, input.event_year || null, input.event_place || null, input.event_value || null]
+      );
+      return rows[0] || null;
+    },
+
+    deleteLifeEvent: async (_: unknown, { id }: { id: number }, context: Context) => {
+      requireAuth(context, 'editor');
+      await pool.query('DELETE FROM life_events WHERE id = $1', [id]);
+      return true;
+    },
+
+    // Fact mutations
+    addFact: async (_: unknown, { personId, input }: { personId: string; input: { fact_type: string; fact_value?: string } }, context: Context) => {
+      requireAuth(context, 'editor');
+      const { rows } = await pool.query(
+        `INSERT INTO facts (person_id, fact_type, fact_value) VALUES ($1, $2, $3) RETURNING *`,
+        [personId, input.fact_type, input.fact_value || null]
+      );
+      return rows[0];
+    },
+
+    updateFact: async (_: unknown, { id, input }: { id: number; input: { fact_type: string; fact_value?: string } }, context: Context) => {
+      requireAuth(context, 'editor');
+      const { rows } = await pool.query(
+        `UPDATE facts SET fact_type = $2, fact_value = $3 WHERE id = $1 RETURNING *`,
+        [id, input.fact_type, input.fact_value || null]
+      );
+      return rows[0] || null;
+    },
+
+    deleteFact: async (_: unknown, { id }: { id: number }, context: Context) => {
+      requireAuth(context, 'editor');
+      await pool.query('DELETE FROM facts WHERE id = $1', [id]);
+      return true;
+    },
+
     addSource: async (_: unknown, { personId, input }: { personId: string; input: { source_type?: string; source_name?: string; source_url?: string; action: string; content?: string; confidence?: string } }, context: Context) => {
       requireAuth(context, 'editor');
 

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -376,11 +376,34 @@ export const typeDefs = `#graphql
     confidence: String
   }
 
+  input LifeEventInput {
+    event_type: String!
+    event_date: String
+    event_year: Int
+    event_place: String
+    event_value: String
+  }
+
+  input FactInput {
+    fact_type: String!
+    fact_value: String
+  }
+
   type Mutation {
     # Person mutations
     createPerson(input: PersonInput!): Person!
     updatePerson(id: ID!, input: PersonInput!): Person
     deletePerson(id: ID!): Boolean!
+
+    # Life event mutations (requires editor role)
+    addLifeEvent(personId: ID!, input: LifeEventInput!): LifeEvent!
+    updateLifeEvent(id: Int!, input: LifeEventInput!): LifeEvent
+    deleteLifeEvent(id: Int!): Boolean!
+
+    # Fact mutations (requires editor role)
+    addFact(personId: ID!, input: FactInput!): Fact!
+    updateFact(id: Int!, input: FactInput!): Fact
+    deleteFact(id: Int!): Boolean!
 
     # Source mutations
     addSource(personId: ID!, input: SourceInput!): Source


### PR DESCRIPTION
Fixes #52

## Changes
- Added GraphQL mutations for life events: addLifeEvent, updateLifeEvent, deleteLifeEvent
- Added GraphQL mutations for facts: addFact, updateFact, deleteFact
- Created LifeEventsEditor component with inline add/edit/delete
- Created FactsEditor component with inline add/edit/delete
- Replaced static displays with editable components on person page

## Event Types Supported
residence, occupation, education, military, immigration, emigration, census, other

## Fact Types Supported
education, religion, nationality, ethnicity, title, nickname, physical_description, coat_of_arms, other

## Testing
- All 147 tests pass
- Build succeeds