### PR TITLE
Fix CI lint warnings and unused variables

### DIFF
--- a/__tests__/lib/resolvers.test.ts
+++ b/__tests__/lib/resolvers.test.ts
@@ -3,9 +3,6 @@
  * Tests core business logic with mocked database
  */
 
-// Create mock function before jest.mock calls
-const mockQuery = jest.fn();
-
 // Mock the database pool - use factory function
 jest.mock('@/lib/pool', () => {
   return {
@@ -18,6 +15,7 @@ jest.mock('@/lib/pool', () => {
 // Mock email functions
 jest.mock('@/lib/email', () => ({
   sendInviteEmail: jest.fn().mockResolvedValue(true),
+  sendPasswordResetEmail: jest.fn().mockResolvedValue(true),
   verifyEmailForSandbox: jest.fn().mockResolvedValue(true),
 }));
 
@@ -480,7 +478,7 @@ describe('GraphQL Resolvers', () => {
       mockedQuery.mockResolvedValueOnce({ rows: [mockPerson] }); // SELECT
 
       const context = { user: { id: 'user-1', email: 'test@example.com', role: 'editor' } };
-      const result = await resolvers.Mutation.updateResearchStatus(
+      await resolvers.Mutation.updateResearchStatus(
         null,
         { personId: 'p1', status: 'verified' },
         context

--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -22,7 +22,7 @@ export default function PeoplePage() {
     variables: { limit: 10000 },
   });
 
-  const people = data?.peopleList || [];
+  const people = useMemo(() => data?.peopleList || [], [data?.peopleList]);
   const [search, setSearch] = useState('');
   const [filter, setFilter] = useState<'all' | 'living' | 'male' | 'female'>('all');
   const [displayCount, setDisplayCount] = useState(PAGE_SIZE);

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -18,17 +18,19 @@ interface TimelineData {
 
 export default function TimelinePage() {
   const { data, loading } = useQuery<TimelineData>(GET_TIMELINE);
-  const timeline = data?.timeline || [];
   const [filter, setFilter] = useState<'all' | 'births' | 'deaths'>('all');
 
-  const filteredTimeline = useMemo(() => timeline.map(t => ({
-    ...t,
-    events: t.events.filter(e =>
-      filter === 'all' ||
-      (filter === 'births' && e.type === 'birth') ||
-      (filter === 'deaths' && e.type === 'death')
-    )
-  })).filter(t => t.events.length > 0), [timeline, filter]);
+  const filteredTimeline = useMemo(() => {
+    const timeline = data?.timeline || [];
+    return timeline.map(t => ({
+      ...t,
+      events: t.events.filter(e =>
+        filter === 'all' ||
+        (filter === 'births' && e.type === 'birth') ||
+        (filter === 'deaths' && e.type === 'death')
+      )
+    })).filter(t => t.events.length > 0);
+  }, [data?.timeline, filter]);
 
   return (
     <>

--- a/app/tree/page.tsx
+++ b/app/tree/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback, Suspense } from 'react';
+import { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { useQuery } from '@apollo/client/react';
@@ -17,7 +17,7 @@ function TreePageContent() {
   const { data, loading } = useQuery<{ peopleList: Person[] }>(GET_PEOPLE_LIST, {
     variables: { limit: 1000 },
   });
-  const people = data?.peopleList || [];
+  const people = useMemo(() => data?.peopleList || [], [data?.peopleList]);
   const [selectedPerson, setSelectedPerson] = useState<string>('');
   const [showAncestors, setShowAncestors] = useState(true);
 

--- a/components/FamilyTree.tsx
+++ b/components/FamilyTree.tsx
@@ -867,9 +867,6 @@ export default function FamilyTree({ rootPersonId, showAncestors, onPersonClick,
       visited.add(nodeKey);
 
       // Both parents should be at the SAME Y level (one generation above current node)
-      // Use the assigned generation from our tracking map
-      const expectedParentY = node.y + levelGap; // Parents are above (higher Y in our coordinate system)
-
       // Ensure both parents use the correct Y (their assigned generation)
       const fatherY = node.father?.y;
       const motherY = node.mother?.y;

--- a/components/ResearchPanel.tsx
+++ b/components/ResearchPanel.tsx
@@ -7,7 +7,7 @@ import { Source, ResearchStatus, ResearchActionType, ResearchSource, ResearchCon
 
 interface ResearchPanelProps {
   personId: string;
-  personName: string;
+  personName?: string;  // Optional - not used but callers may pass it
   compact?: boolean;
 }
 
@@ -61,7 +61,7 @@ const STATUS_OPTIONS: { value: ResearchStatus; label: string; color: string; des
   { value: 'brick_wall', label: 'Brick Wall', color: 'bg-red-200', desc: 'Cannot find more info' },
 ];
 
-export default function ResearchPanel({ personId, personName, compact = false }: ResearchPanelProps) {
+export default function ResearchPanel({ personId, compact = false }: ResearchPanelProps) {
   const [showForm, setShowForm] = useState(false);
 
   // Form state

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -124,7 +124,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
       // No user and no invitation - deny access
       return false;
     },
-    async session({ session, token }) {
+    async session({ session }) {
       if (session.user?.email) {
         const userResult = await pool.query(
           'SELECT id, role FROM users WHERE email = $1',

--- a/lib/graphql/server.ts
+++ b/lib/graphql/server.ts
@@ -3,7 +3,7 @@
  * This allows server components to query GraphQL without HTTP overhead
  */
 
-import { graphql, GraphQLSchema, buildSchema, print, DocumentNode } from 'graphql';
+import { graphql, GraphQLSchema, print, DocumentNode } from 'graphql';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { typeDefs } from './schema';
 import { resolvers } from './resolvers';


### PR DESCRIPTION
Cleans up all CI lint warnings:

## Unused variables removed
- lib/graphql/server.ts: buildSchema import
- lib/auth.ts: token param in session callback
- components/FamilyTree.tsx: expectedParentY variable
- __tests__/lib/resolvers.test.ts: mockQuery and result

## React hook dependency fixes
- app/tree/page.tsx: wrap people in useMemo
- app/timeline/page.tsx: move timeline inside useMemo callback
- app/people/page.tsx: wrap people in useMemo

## Other fixes
- components/ResearchPanel.tsx: make personName optional
- Add sendPasswordResetEmail to email mock (fixes console.error in tests)

Closes #70