### PR TITLE
fix: Sidebar slider visibility and tree resize on sidebar collapse

### DIFF
--- a/components/FamilyTree.tsx
+++ b/components/FamilyTree.tsx
@@ -214,7 +214,7 @@ export default function FamilyTree({ rootPersonId, showAncestors, onPersonClick,
     await updateStatus({ variables: { personId, status } });
   };
 
-  // Handle resize
+  // Handle resize - use ResizeObserver to detect container size changes (e.g., sidebar collapse)
   useEffect(() => {
     const updateDimensions = () => {
       if (containerRef.current) {
@@ -225,8 +225,19 @@ export default function FamilyTree({ rootPersonId, showAncestors, onPersonClick,
       }
     };
     updateDimensions();
+
+    // ResizeObserver detects container size changes from sidebar collapse
+    const resizeObserver = new ResizeObserver(updateDimensions);
+    if (containerRef.current) {
+      resizeObserver.observe(containerRef.current);
+    }
+
+    // Also listen to window resize as fallback
     window.addEventListener('resize', updateDimensions);
-    return () => window.removeEventListener('resize', updateDimensions);
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', updateDimensions);
+    };
   }, []);
 
   // Build descendant chain for collateral branches (e.g., Renée -> ... -> Joséphine)

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -116,7 +116,7 @@ export default function Sidebar() {
       </div>
 
       {/* Navigation */}
-      <div className="flex-1 overflow-y-auto py-4">
+      <div className={`flex-1 py-4 ${isCollapsed ? 'overflow-hidden' : 'overflow-y-auto'}`}>
         {/* Main section */}
         {!isCollapsed && (
           <div className="px-4 mb-2">


### PR DESCRIPTION
Fixes two UI issues:

## Changes
- **Sidebar (#79)**: Hide scrollbar in collapsed sidebar to prevent slider artifact appearing at bottom
- **FamilyTree (#80)**: Add ResizeObserver to detect container size changes when sidebar collapses, triggering proper tree re-render

## Testing
1. Navigate to Tree view
2. Collapse sidebar using the toggle button
3. Verify: No slider/scrollbar visible at bottom of collapsed sidebar
4. Verify: Tree visualization expands to fill available space

Closes #79
Closes #80