### PR TITLE
refactor: Use React Context for sidebar collapsed state

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -218,9 +218,7 @@ body {
   transition: margin-left var(--transition-normal);
 }
 
-body.sidebar-is-collapsed .main-content {
-  margin-left: var(--sidebar-collapsed-width);
-}
+/* Sidebar collapsed state is now handled via React Context in MainContent component */
 .content-wrapper { flex: 1; overflow-y: auto; padding: 2rem; }
 
 /* Hero (legacy) */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { Providers } from "@/components/Providers";
 import Sidebar from "@/components/Sidebar";
+import MainContent from "@/components/MainContent";
 import Footer from "@/components/Footer";
 import { getSettings } from "@/lib/settings";
 
@@ -58,10 +59,10 @@ export default async function RootLayout({
       <body>
         <Providers settings={settings}>
           <Sidebar />
-          <main className="main-content">
+          <MainContent>
             {children}
             <Footer />
-          </main>
+          </MainContent>
         </Providers>
       </body>
     </html>

--- a/components/MainContent.tsx
+++ b/components/MainContent.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useSidebar } from './SidebarContext';
+
+interface MainContentProps {
+  children: React.ReactNode;
+}
+
+export default function MainContent({ children }: MainContentProps) {
+  const { isCollapsed } = useSidebar();
+
+  return (
+    <main
+      className="main-content"
+      style={{
+        marginLeft: isCollapsed ? 'var(--sidebar-collapsed-width)' : 'var(--sidebar-width)',
+      }}
+    >
+      {children}
+    </main>
+  );
+}
+

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -5,6 +5,7 @@ import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client/core';
 import { ApolloProvider } from '@apollo/client/react';
 import { useMemo } from 'react';
 import { SettingsProvider, SiteSettings } from './SettingsProvider';
+import { SidebarProvider } from './SidebarContext';
 
 function ApolloWrapper({ children }: { children: React.ReactNode }) {
   const client = useMemo(() => {
@@ -47,7 +48,9 @@ export function Providers({ children, settings }: ProvidersProps) {
     <SessionProvider refetchOnWindowFocus={false} refetchInterval={0}>
       <ApolloWrapper>
         <SettingsProvider settings={settings}>
-          {children}
+          <SidebarProvider>
+            {children}
+          </SidebarProvider>
         </SettingsProvider>
       </ApolloWrapper>
     </SessionProvider>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
 import { useSettings } from './SettingsProvider';
+import { useSidebar } from './SidebarContext';
 import {
   LayoutDashboard,
   TreeDeciduous,
@@ -65,27 +65,8 @@ export default function Sidebar() {
   const pathname = usePathname();
   const { data: session, status } = useSession();
   const settings = useSettings();
+  const { isCollapsed, toggleCollapse } = useSidebar();
   const isAdmin = session?.user?.role === 'admin';
-
-  // Persist collapsed state in localStorage
-  const [isCollapsed, setIsCollapsed] = useState(() => {
-    // Initialize from localStorage (only runs on client)
-    if (typeof window !== 'undefined') {
-      return localStorage.getItem('sidebar-collapsed') === 'true';
-    }
-    return false;
-  });
-
-  // Sync body class with collapsed state
-  useEffect(() => {
-    document.body.classList.toggle('sidebar-is-collapsed', isCollapsed);
-  }, [isCollapsed]);
-
-  const toggleCollapse = () => {
-    const newState = !isCollapsed;
-    setIsCollapsed(newState);
-    localStorage.setItem('sidebar-collapsed', String(newState));
-  };
 
   // Don't show sidebar on login page or when not authenticated
   if (pathname === '/login' || status === 'unauthenticated') {

--- a/components/SidebarContext.tsx
+++ b/components/SidebarContext.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
+interface SidebarContextType {
+  isCollapsed: boolean;
+  toggleCollapse: () => void;
+  setCollapsed: (collapsed: boolean) => void;
+}
+
+const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
+
+export function SidebarProvider({ children }: { children: ReactNode }) {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Initialize from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem('sidebar-collapsed');
+    if (stored !== null) {
+      setIsCollapsed(stored === 'true');
+    }
+    setIsInitialized(true);
+  }, []);
+
+  const toggleCollapse = () => {
+    const newState = !isCollapsed;
+    setIsCollapsed(newState);
+    localStorage.setItem('sidebar-collapsed', String(newState));
+  };
+
+  const setCollapsed = (collapsed: boolean) => {
+    setIsCollapsed(collapsed);
+    localStorage.setItem('sidebar-collapsed', String(collapsed));
+  };
+
+  // Don't render children until initialized to prevent hydration mismatch
+  if (!isInitialized) {
+    return null;
+  }
+
+  return (
+    <SidebarContext.Provider value={{ isCollapsed, toggleCollapse, setCollapsed }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+}
+
+export function useSidebar() {
+  const context = useContext(SidebarContext);
+  if (context === undefined) {
+    throw new Error('useSidebar must be used within a SidebarProvider');
+  }
+  return context;
+}
+


### PR DESCRIPTION
Replaces body class manipulation with React Context for sidebar state management. Closes #76