### PR TITLE
feat: Add service accounts for API access

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -14,7 +14,9 @@ import {
   DELETE_INVITATION,
   UPDATE_USER_ROLE,
   DELETE_USER,
-  CREATE_LOCAL_USER
+  CREATE_LOCAL_USER,
+  CREATE_SERVICE_ACCOUNT,
+  REVOKE_SERVICE_ACCOUNT
 } from '@/lib/graphql/queries';
 
 interface User {
@@ -22,6 +24,8 @@ interface User {
   email: string;
   name: string | null;
   role: string;
+  account_type?: string;
+  description?: string | null;
   created_at: string;
   last_login: string | null;
   last_accessed: string | null;
@@ -53,6 +57,14 @@ export default function AdminPage() {
   const [requirePasswordChange, setRequirePasswordChange] = useState(true);
   const [createUserError, setCreateUserError] = useState('');
 
+  // Service account state
+  const [showServiceAccount, setShowServiceAccount] = useState(false);
+  const [serviceAccountName, setServiceAccountName] = useState('');
+  const [serviceAccountDescription, setServiceAccountDescription] = useState('');
+  const [serviceAccountRole, setServiceAccountRole] = useState('viewer');
+  const [newServiceAccountKey, setNewServiceAccountKey] = useState('');
+  const [serviceAccountError, setServiceAccountError] = useState('');
+
   // Generate a secure random password
   const generatePassword = useCallback(() => {
     const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*';
@@ -76,8 +88,12 @@ export default function AdminPage() {
   const [updateUserRole] = useMutation(UPDATE_USER_ROLE);
   const [deleteUser] = useMutation(DELETE_USER);
   const [createLocalUser] = useMutation(CREATE_LOCAL_USER);
+  const [createServiceAccount] = useMutation(CREATE_SERVICE_ACCOUNT);
+  const [revokeServiceAccount] = useMutation(REVOKE_SERVICE_ACCOUNT);
 
-  const users = usersData?.users || [];
+  const allUsers = usersData?.users || [];
+  const users = allUsers.filter(u => u.account_type !== 'service');
+  const serviceAccounts = allUsers.filter(u => u.account_type === 'service');
   const invitations = invitationsData?.invitations || [];
   const loading = usersLoading || invitationsLoading;
 
@@ -162,6 +178,41 @@ export default function AdminPage() {
       refetchUsers();
     } catch (err) {
       setCreateUserError(err instanceof Error ? err.message : 'Failed to create user');
+    }
+  };
+
+  const handleCreateServiceAccount = async () => {
+    if (!serviceAccountName.trim()) {
+      setServiceAccountError('Name is required');
+      return;
+    }
+    setServiceAccountError('');
+    try {
+      const result = await createServiceAccount({
+        variables: {
+          name: serviceAccountName,
+          description: serviceAccountDescription || null,
+          role: serviceAccountRole
+        }
+      });
+      const data = result.data as { createServiceAccount: { apiKey: string } };
+      setNewServiceAccountKey(data.createServiceAccount.apiKey);
+      setServiceAccountName('');
+      setServiceAccountDescription('');
+      setServiceAccountRole('viewer');
+      refetchUsers();
+    } catch (err) {
+      setServiceAccountError(err instanceof Error ? err.message : 'Failed to create service account');
+    }
+  };
+
+  const handleRevokeServiceAccount = async (userId: string) => {
+    if (!confirm('Are you sure you want to revoke this service account? This cannot be undone.')) return;
+    try {
+      await revokeServiceAccount({ variables: { userId } });
+      refetchUsers();
+    } catch (err) {
+      console.error('Failed to revoke service account:', err);
     }
   };
 
@@ -406,6 +457,104 @@ export default function AdminPage() {
               ))}
             </tbody>
           </table>
+        </div>
+
+        {/* Service Accounts Section */}
+        <div className="bg-white rounded-xl shadow-sm border p-6 mt-8">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-xl font-semibold">Service Accounts ({serviceAccounts.length})</h2>
+            <Button
+              onClick={() => { setShowServiceAccount(!showServiceAccount); setNewServiceAccountKey(''); }}
+              variant={showServiceAccount ? 'primary' : 'secondary'}
+              size="sm"
+              icon={<UserPlus className="w-4 h-4" />}
+            >
+              {showServiceAccount ? 'Cancel' : 'Create Service Account'}
+            </Button>
+          </div>
+
+          {showServiceAccount && (
+            <div className="bg-gray-50 rounded-lg p-4 mb-6">
+              {serviceAccountError && (
+                <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-2 rounded-lg mb-4">
+                  {serviceAccountError}
+                </div>
+              )}
+              {newServiceAccountKey ? (
+                <div className="space-y-4">
+                  <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+                    <p className="text-green-800 font-medium mb-2">✓ Service account created!</p>
+                    <p className="text-sm text-green-700 mb-3">Copy the API key now. It will not be shown again.</p>
+                    <div className="flex items-center gap-2 bg-white rounded p-2 border">
+                      <code className="text-sm font-mono flex-1 break-all">{newServiceAccountKey}</code>
+                      <Button
+                        onClick={() => { navigator.clipboard.writeText(newServiceAccountKey); }}
+                        variant="ghost"
+                        size="sm"
+                        icon={<Copy className="w-4 h-4" />}
+                      >
+                        Copy
+                      </Button>
+                    </div>
+                  </div>
+                  <Button onClick={() => { setShowServiceAccount(false); setNewServiceAccountKey(''); }} variant="secondary">
+                    Done
+                  </Button>
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Name *</label>
+                      <input type="text" value={serviceAccountName} onChange={e => setServiceAccountName(e.target.value)}
+                        className="w-full border rounded-lg px-3 py-2" placeholder="e.g., Backup Script" />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Role</label>
+                      <select value={serviceAccountRole} onChange={e => setServiceAccountRole(e.target.value)}
+                        className="w-full border rounded-lg px-3 py-2">
+                        <option value="viewer">Viewer (read-only)</option>
+                        <option value="editor">Editor (read/write)</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+                    <input type="text" value={serviceAccountDescription} onChange={e => setServiceAccountDescription(e.target.value)}
+                      className="w-full border rounded-lg px-3 py-2" placeholder="What is this service account for?" />
+                  </div>
+                  <Button onClick={handleCreateServiceAccount} icon={<UserPlus className="w-4 h-4" />}>
+                    Create Service Account
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {serviceAccounts.length === 0 ? (
+            <p className="text-gray-500">No service accounts</p>
+          ) : (
+            <table className="w-full">
+              <thead><tr className="text-left text-sm text-gray-500 border-b">
+                <th className="pb-2">Name</th><th className="pb-2">Role</th><th className="pb-2">Description</th><th className="pb-2">Created</th><th></th>
+              </tr></thead>
+              <tbody>
+                {serviceAccounts.map(sa => (
+                  <tr key={sa.id} className="border-b">
+                    <td className="py-3 font-medium">{sa.name}</td>
+                    <td className="py-3 capitalize">{sa.role}</td>
+                    <td className="py-3 text-gray-500 text-sm">{sa.description || '-'}</td>
+                    <td className="py-3 text-sm text-gray-500">{new Date(sa.created_at).toLocaleDateString()}</td>
+                    <td className="py-3 text-right">
+                      <Button onClick={() => handleRevokeServiceAccount(sa.id)} variant="danger" size="sm" icon={<Trash2 className="w-3 h-3" />}>
+                        Revoke
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
       </div>
     </>

--- a/lib/auth-types.ts
+++ b/lib/auth-types.ts
@@ -21,6 +21,8 @@ export interface AppUser {
   name: string | null;
   image: string | null;
   role: 'admin' | 'editor' | 'viewer';
+  account_type: 'user' | 'service';
+  description: string | null;
   invited_by: string | null;
   invited_at: Date | null;
   created_at: Date;

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -510,6 +510,8 @@ export const GET_USERS = gql`
       email
       name
       role
+      account_type
+      description
       created_at
       last_login
       last_accessed
@@ -574,6 +576,32 @@ export const CREATE_LOCAL_USER = gql`
       role
       created_at
     }
+  }
+`;
+
+// ============================================
+// SERVICE ACCOUNTS
+// ============================================
+
+export const CREATE_SERVICE_ACCOUNT = gql`
+  mutation CreateServiceAccount($name: String!, $description: String, $role: String!) {
+    createServiceAccount(name: $name, description: $description, role: $role) {
+      user {
+        id
+        name
+        role
+        account_type
+        description
+        created_at
+      }
+      apiKey
+    }
+  }
+`;
+
+export const REVOKE_SERVICE_ACCOUNT = gql`
+  mutation RevokeServiceAccount($userId: ID!) {
+    revokeServiceAccount(userId: $userId)
   }
 `;
 

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -149,6 +149,8 @@ export const typeDefs = `#graphql
     email: String!
     name: String
     role: String!
+    account_type: String!
+    description: String
     created_at: String!
     last_login: String
     last_accessed: String
@@ -164,6 +166,12 @@ export const typeDefs = `#graphql
     expires_at: String!
     accepted_at: String
     created_by: String
+  }
+
+  # Service account creation result (includes API key shown once)
+  type ServiceAccountResult {
+    user: User!
+    apiKey: String!
   }
 
   # ===========================================
@@ -441,6 +449,10 @@ export const typeDefs = `#graphql
     createLocalUser(email: String!, name: String!, role: String!, password: String!, requirePasswordChange: Boolean): User!
     updateUserRole(userId: ID!, role: String!): User
     deleteUser(userId: ID!): Boolean
+
+    # Service account mutations (requires admin role)
+    createServiceAccount(name: String!, description: String, role: String!): ServiceAccountResult!
+    revokeServiceAccount(userId: ID!): Boolean!
 
     # Settings mutations (requires admin role)
     updateSettings(input: SettingsInput!): SiteSettings!


### PR DESCRIPTION
Adds service account functionality for programmatic API access.

## Features
- Create service accounts with name, description, and role (viewer/editor)
- Auto-generate API key on creation (shown once, not retrievable later)
- List and revoke service accounts from admin panel
- Service accounts cannot be admin role for security

## Database Migration
Run migration 003_service_accounts.sql to add account_type and description columns.

Closes #73