### PR TITLE
feat: Add GEDCOM import functionality

### DIFF
--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -717,11 +717,22 @@ export const GET_SITE_SETTINGS = gql`
 `;
 
 // ============================================
-// GEDCOM EXPORT
+// GEDCOM EXPORT/IMPORT
 // ============================================
 
 export const EXPORT_GEDCOM = gql`
   query ExportGedcom($includeLiving: Boolean, $includeSources: Boolean) {
     exportGedcom(includeLiving: $includeLiving, includeSources: $includeSources)
+  }
+`;
+
+export const IMPORT_GEDCOM = gql`
+  mutation ImportGedcom($content: String!) {
+    importGedcom(content: $content) {
+      peopleImported
+      familiesImported
+      errors
+      warnings
+    }
   }
 `;

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -473,12 +473,22 @@ export const typeDefs = `#graphql
     requestPasswordReset(email: String!): Boolean!
     resetPassword(token: String!, newPassword: String!): AuthResult!
     changePassword(currentPassword: String!, newPassword: String!): Boolean!
+
+    # GEDCOM import (requires admin role)
+    importGedcom(content: String!): GedcomImportResult!
   }
 
   type AuthResult {
     success: Boolean!
     message: String
     userId: String
+  }
+
+  type GedcomImportResult {
+    peopleImported: Int!
+    familiesImported: Int!
+    errors: [String!]!
+    warnings: [String!]!
   }
 `;
 


### PR DESCRIPTION
Adds GEDCOM 5.5.1 import capability for family tree data.

## Features
- Parse standard GEDCOM 5.5.1 format files
- Import individuals (INDI) with names, dates, places
- Import families (FAM) with spouses and children
- Map GEDCOM xrefs to database IDs for relationships
- Error and warning reporting
- Import results display

## Implementation
- Extended lib/gedcom.ts with parseGedcom function
- GraphQL mutation: importGedcom(content)
- Import UI in Admin > Settings page with file upload

## Supported Tags
- INDI: NAME, SEX, BIRT, DEAT, BURI, CHR
- FAM: HUSB, WIFE, CHIL, MARR
- Event details: DATE, PLAC

Closes #57