### PR TITLE
fix: research page 500 error with live API proxy support

### DIFF
--- a/lib/graphql/server.ts
+++ b/lib/graphql/server.ts
@@ -1,6 +1,7 @@
 /**
  * Server-side GraphQL execution for Next.js Server Components
  * This allows server components to query GraphQL without HTTP overhead
+ * When USE_LIVE_API=true, queries are proxied to the production API
  */
 
 import { graphql, GraphQLSchema, print, DocumentNode } from 'graphql';
@@ -8,6 +9,10 @@ import { makeExecutableSchema } from '@graphql-tools/schema';
 import { typeDefs } from './schema';
 import { resolvers } from './resolvers';
 import { createLoaders } from './dataloaders';
+
+const USE_LIVE_API = process.env.USE_LIVE_API === 'true';
+const GRAPHQL_PROXY_URL = process.env.GRAPHQL_PROXY_URL;
+const GRAPHQL_PROXY_API_KEY = process.env.GRAPHQL_PROXY_API_KEY;
 
 // Build the executable schema once
 let executableSchema: GraphQLSchema | null = null;
@@ -28,26 +33,55 @@ export interface GraphQLResult<T> {
 }
 
 /**
+ * Execute a GraphQL query via proxy to production API
+ */
+async function executeViaProxy<T>(
+  queryString: string,
+  variables?: Record<string, unknown>
+): Promise<GraphQLResult<T>> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (GRAPHQL_PROXY_API_KEY) {
+    headers['X-API-Key'] = GRAPHQL_PROXY_API_KEY;
+  }
+
+  const response = await fetch(GRAPHQL_PROXY_URL!, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query: queryString, variables }),
+  });
+
+  return response.json();
+}
+
+/**
  * Execute a GraphQL query on the server side (no HTTP)
  * For use in Server Components
+ * When USE_LIVE_API=true, proxies to production API instead
  */
 export async function executeQuery<T = Record<string, unknown>>(
   query: DocumentNode | string,
   variables?: Record<string, unknown>,
   user?: { id: string; email: string; role: string }
 ): Promise<GraphQLResult<T>> {
+  const queryString = typeof query === 'string' ? query : print(query);
+
+  // Use proxy for live API testing
+  if (USE_LIVE_API && GRAPHQL_PROXY_URL) {
+    return executeViaProxy<T>(queryString, variables);
+  }
+
   const schema = getSchema();
   const loaders = createLoaders();
-  
-  const queryString = typeof query === 'string' ? query : print(query);
-  
+
   const result = await graphql({
     schema,
     source: queryString,
     variableValues: variables,
     contextValue: { user, loaders },
   });
-  
+
   return result as GraphQLResult<T>;
 }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,11 +1,21 @@
 import NextAuth from 'next-auth';
 import authConfig from './auth.config';
 
+// Skip auth ONLY in development mode when SKIP_AUTH=true
+// Both conditions must be true - prevents accidental bypass in production
+const SKIP_AUTH =
+  process.env.SKIP_AUTH === 'true' && process.env.NODE_ENV === 'development';
+
 // Create a lightweight auth instance for proxy (no database)
 const { auth } = NextAuth(authConfig);
 
 // Wrap auth for route protection
 export default auth((req) => {
+  // Allow all requests only in dev mode with explicit SKIP_AUTH
+  if (SKIP_AUTH) {
+    return;
+  }
+
   const isLoggedIn = !!req.auth;
   const { pathname } = req.nextUrl;
 


### PR DESCRIPTION
## Summary
Fixes the 500 error on /research page when using the live API proxy for local development.

## Changes
- **lib/graphql/server.ts**: Add \executeViaProxy()\ function for server-side GraphQL queries
  - Server components now use the proxy when \USE_LIVE_API=true  - Previously only client-side Apollo queries used the proxy
- **proxy.ts**: Add secure \SKIP_AUTH\ bypass for local development
  - Requires BOTH \SKIP_AUTH=true\ AND \NODE_ENV=development  - Cannot be accidentally enabled in production
- **.env.example**: Document SKIP_AUTH option

## Testing
1. Set \USE_LIVE_API=true\, \GRAPHQL_PROXY_URL\, \GRAPHQL_PROXY_API_KEY\, \SKIP_AUTH=true\ in .env.local
2. Run pm run dev3. Navigate to /research - should show 100 people from live database

Closes #108