### PR TITLE
fix: align Photos & Documents styling with design system

### DIFF
--- a/components/MediaGallery.tsx
+++ b/components/MediaGallery.tsx
@@ -94,9 +94,9 @@ export default function MediaGallery({ personId, media, canEdit, onMediaChange }
   const getMediaUrl = (item: MediaItem) => item.url || `/api/media/${item.filename}`;
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold">📷 Photos & Documents</h3>
+    <div className="card p-6 mb-6">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="section-title">📷 Photos & Documents ({media.length})</h3>
         {canEdit && (
           <>
             <input
@@ -107,6 +107,7 @@ export default function MediaGallery({ personId, media, canEdit, onMediaChange }
               className="hidden"
             />
             <Button
+              variant="secondary"
               onClick={() => fileInputRef.current?.click()}
               disabled={uploading}
               loading={uploading}
@@ -122,11 +123,11 @@ export default function MediaGallery({ personId, media, canEdit, onMediaChange }
       {media.length === 0 ? (
         <p className="text-gray-500 text-sm">No photos or documents yet.</p>
       ) : (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
           {media.map((item) => (
             <div
               key={item.id}
-              className="relative group cursor-pointer rounded-lg overflow-hidden border hover:border-blue-500 transition-colors"
+              className="relative group cursor-pointer rounded-lg overflow-hidden border border-border hover:border-primary transition-colors bg-muted"
               onClick={() => setSelectedMedia(item)}
             >
               {item.mime_type.startsWith('image/') ? (
@@ -139,11 +140,11 @@ export default function MediaGallery({ personId, media, canEdit, onMediaChange }
                   unoptimized
                 />
               ) : (
-                <div className="w-full h-32 flex items-center justify-center bg-gray-100">
+                <div className="w-full h-32 flex items-center justify-center bg-muted text-muted-foreground">
                   {getMediaIcon(item.mime_type)}
                 </div>
               )}
-              <div className="absolute bottom-0 left-0 right-0 bg-black/50 text-white text-xs p-1 truncate">
+              <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-xs p-2 truncate">
                 {item.caption || item.original_filename}
               </div>
             </div>
@@ -153,15 +154,15 @@ export default function MediaGallery({ personId, media, canEdit, onMediaChange }
 
       {/* Lightbox */}
       {selectedMedia && (
-        <div className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4" onClick={() => setSelectedMedia(null)}>
+        <div className="fixed inset-0 bg-background/95 backdrop-blur-sm z-50 flex items-center justify-center p-4" onClick={() => setSelectedMedia(null)}>
           <div className="relative max-w-4xl max-h-full" onClick={(e) => e.stopPropagation()}>
             <Button
               variant="ghost"
               size="icon"
               onClick={() => setSelectedMedia(null)}
-              className="absolute -top-10 right-0 text-white hover:text-gray-300 hover:bg-transparent"
+              className="absolute -top-12 right-0 text-foreground hover:bg-muted"
             >
-              <X className="w-8 h-8" />
+              <X className="w-6 h-6" />
             </Button>
             {selectedMedia.mime_type.startsWith('image/') ? (
               <NextImage
@@ -169,16 +170,16 @@ export default function MediaGallery({ personId, media, canEdit, onMediaChange }
                 alt={selectedMedia.caption || selectedMedia.original_filename}
                 width={800}
                 height={600}
-                className="max-h-[80vh] w-auto rounded-lg"
+                className="max-h-[80vh] w-auto rounded-lg shadow-lg"
                 unoptimized
               />
             ) : (
-              <iframe src={getMediaUrl(selectedMedia)} title={selectedMedia.original_filename} className="w-[80vw] h-[80vh] bg-white rounded-lg" />
+              <iframe src={getMediaUrl(selectedMedia)} title={selectedMedia.original_filename} className="w-[80vw] h-[80vh] bg-card rounded-lg shadow-lg" />
             )}
-            <div className="mt-2 text-white text-center">
-              <p>{selectedMedia.caption || selectedMedia.original_filename}</p>
+            <div className="mt-4 text-center">
+              <p className="text-foreground font-medium">{selectedMedia.caption || selectedMedia.original_filename}</p>
               {canEdit && (
-                <Button variant="destructive" size="sm" className="mt-2" onClick={() => handleDelete(selectedMedia.id)} icon={<Trash2 className="w-4 h-4" />}>
+                <Button variant="destructive" size="sm" className="mt-3" onClick={() => handleDelete(selectedMedia.id)} icon={<Trash2 className="w-4 h-4" />}>
                   Delete
                 </Button>
               )}


### PR DESCRIPTION
## Summary
Updates MediaGallery component to match the design system used by other editor components.

## Changes
- Wrap in \card p-6 mb-6\ for consistent card styling
- Use \section-title\ class for header
- Add media count to header (matches Sources, Life Events, etc.)
- Button variant changed to \secondary\ (matches other editors)
- Use theme colors: \order-border\, \g-muted\, \	ext-muted-foreground- Lightbox updated with \ackdrop-blur-sm\ and theme-aware colors
- Works correctly in both light and dark modes

Closes #120