### PR TITLE
fix: search page updates when URL query changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ update-vpc.sh
 update-service.json
 terraform/
 .jest-cache/
+.eslintcache

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,8 +12,10 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
-    // Generated files
+    // Performance: skip generated/cached files
     "coverage/**",
+    ".jest-cache/**",
+    "node_modules/**",
   ]),
 ]);
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint",
+    "lint": "eslint --cache --cache-location .eslintcache",
     "test": "jest --coverage",
     "test:fast": "jest --no-coverage",
     "test:watch": "jest --watch --no-coverage",


### PR DESCRIPTION
Fixes the issue where navigating from GlobalSearch to /search?q=query would not update results on subsequent URL changes.

## Changes
- Track search term with ref for display, derive from URL or ref
- Use Apollo called state for searched flag
- Wrap rawResults in useMemo for performance
- Add ESLint caching for faster lint runs
- Add .eslintcache to .gitignore

Closes #131

