### PR TITLE
fix: dark mode refinements - replace hardcoded colors with CSS variables

### DIFF
--- a/components/CreatePersonModal.tsx
+++ b/components/CreatePersonModal.tsx
@@ -91,10 +91,10 @@ export default function CreatePersonModal({ isOpen, onClose, onSuccess }: Create
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto m-4">
-        <div className="p-6 border-b">
+      <div className="bg-[var(--card)] text-[var(--card-foreground)] rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto m-4">
+        <div className="p-6 border-b border-[var(--border)]">
           <div className="flex justify-between items-center">
-            <h2 className="text-2xl font-bold text-gray-900">Add New Person</h2>
+            <h2 className="text-2xl font-bold">Add New Person</h2>
             <Button variant="ghost" size="icon" onClick={() => { resetForm(); onClose(); }}><X className="w-5 h-5" /></Button>
           </div>
         </div>
@@ -106,7 +106,7 @@ export default function CreatePersonModal({ isOpen, onClose, onSuccess }: Create
           
           {/* Name Section */}
           <div className="space-y-4">
-            <h3 className="font-semibold text-gray-700 border-b pb-2">Name</h3>
+            <h3 className="font-semibold text-[var(--muted-foreground)] border-b border-[var(--border)] pb-2">Name</h3>
             <div className="space-y-2">
               <Label>Full Name *</Label>
               <Input type="text" required value={formData.name_full}
@@ -131,7 +131,7 @@ export default function CreatePersonModal({ isOpen, onClose, onSuccess }: Create
           
           {/* Demographics */}
           <div className="space-y-4">
-            <h3 className="font-semibold text-gray-700 border-b pb-2">Demographics</h3>
+            <h3 className="font-semibold text-[var(--muted-foreground)] border-b border-[var(--border)] pb-2">Demographics</h3>
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label>Sex</Label>
@@ -156,7 +156,7 @@ export default function CreatePersonModal({ isOpen, onClose, onSuccess }: Create
           
           {/* Birth */}
           <div className="space-y-4">
-            <h3 className="font-semibold text-gray-700 border-b pb-2">Birth</h3>
+            <h3 className="font-semibold text-[var(--muted-foreground)] border-b border-[var(--border)] pb-2">Birth</h3>
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
                 <Label>Birth Year</Label>
@@ -176,7 +176,7 @@ export default function CreatePersonModal({ isOpen, onClose, onSuccess }: Create
           {/* Death (hidden if living) */}
           {!formData.living && (
             <div className="space-y-4">
-              <h3 className="font-semibold text-gray-700 border-b pb-2">Death</h3>
+              <h3 className="font-semibold text-[var(--muted-foreground)] border-b border-[var(--border)] pb-2">Death</h3>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
                   <Label>Death Year</Label>

--- a/components/EditPersonModal.tsx
+++ b/components/EditPersonModal.tsx
@@ -125,10 +125,10 @@ export default function EditPersonModal({ person, isOpen, onClose, onSuccess }: 
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl shadow-2xl w-full max-w-3xl max-h-[90vh] overflow-y-auto m-4">
-        <div className="p-6 border-b sticky top-0 bg-white z-10">
+      <div className="bg-[var(--card)] text-[var(--card-foreground)] rounded-xl shadow-2xl w-full max-w-3xl max-h-[90vh] overflow-y-auto m-4">
+        <div className="p-6 border-b border-[var(--border)] sticky top-0 bg-[var(--card)] z-10">
           <div className="flex justify-between items-center">
-            <h2 className="text-2xl font-bold text-gray-900">Edit Person</h2>
+            <h2 className="text-2xl font-bold">Edit Person</h2>
             <Button variant="ghost" size="icon" onClick={onClose}><X className="w-5 h-5" /></Button>
           </div>
         </div>
@@ -252,7 +252,7 @@ export default function EditPersonModal({ person, isOpen, onClose, onSuccess }: 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div className="space-y-4">
-      <h3 className="font-semibold text-gray-700 border-b pb-2">{title}</h3>
+      <h3 className="font-semibold text-[var(--muted-foreground)] border-b border-[var(--border)] pb-2">{title}</h3>
       {children}
     </div>
   );

--- a/components/FactsEditor.tsx
+++ b/components/FactsEditor.tsx
@@ -102,14 +102,14 @@ export default function FactsEditor({ personId, facts, canEdit }: Props) {
       )}
 
       {displayFacts.length === 0 && !showForm ? (
-        <p className="text-gray-500 text-sm">No additional facts recorded.</p>
+        <p className="text-[var(--muted-foreground)] text-sm">No additional facts recorded.</p>
       ) : (
         <div className="space-y-2">
           {displayFacts.map((fact) => (
             <div key={fact.id} className="flex items-center justify-between text-sm group">
               <div>
-                <span className="text-gray-600 font-medium">{getIcon(fact.fact_type)} {fact.fact_type?.replace(/_/g, ' ') || 'Fact'}:</span>{' '}
-                <span className="text-gray-800">{fact.fact_value}</span>
+                <span className="text-[var(--muted-foreground)] font-medium">{getIcon(fact.fact_type)} {fact.fact_type?.replace(/_/g, ' ') || 'Fact'}:</span>{' '}
+                <span className="text-[var(--foreground)]">{fact.fact_value}</span>
               </div>
               {canEdit && (
                 <div className="opacity-0 group-hover:opacity-100 flex gap-1">

--- a/components/FamilyEditor.tsx
+++ b/components/FamilyEditor.tsx
@@ -159,11 +159,11 @@ export default function FamilyEditor({ personId, personSex, families, canEdit }:
               <>
                 {spouse && (
                   <div className="mb-4">
-                    <p className="text-sm text-gray-500 mb-2">Spouse</p>
-                    <div className={`p-4 rounded-lg border-l-4 ${spouse.sex === 'F' ? 'border-l-pink-400 bg-pink-50' : 'border-l-blue-400 bg-blue-50'} flex justify-between items-start`}>
+                    <p className="text-sm text-[var(--muted-foreground)] mb-2">Spouse</p>
+                    <div className={`p-4 rounded-lg border-l-4 ${spouse.sex === 'F' ? 'border-l-pink-400 bg-pink-50 dark:bg-pink-950' : 'border-l-blue-400 bg-blue-50 dark:bg-blue-950'} flex justify-between items-start`}>
                       <Link href={`/person/${spouse.id}`} className="flex-1">
                         <p className="font-semibold">{spouse.name_full}</p>
-                        <p className="text-sm text-gray-500">
+                        <p className="text-sm text-[var(--muted-foreground)]">
                           {family.marriage_place && `Married in ${family.marriage_place}`}
                           {family.marriage_year && ` (${family.marriage_year})`}
                         </p>
@@ -176,7 +176,7 @@ export default function FamilyEditor({ personId, personSex, families, canEdit }:
                 {/* Children */}
                 <div>
                   <div className="flex justify-between items-center mb-2">
-                    <p className="text-sm text-gray-500">Children ({family.children.length})</p>
+                    <p className="text-sm text-[var(--muted-foreground)]">Children ({family.children.length})</p>
                     {canEdit && (
                       <Button variant="link" size="sm" onClick={() => setAddingChildTo(addingChildTo === family.id ? null : family.id)}>
                         {addingChildTo === family.id ? 'Cancel' : '+ Add Child'}

--- a/components/FamilyTree.tsx
+++ b/components/FamilyTree.tsx
@@ -1270,13 +1270,13 @@ export default function FamilyTree({ rootPersonId, showAncestors, onPersonClick,
         </div>
       )}
       {loading && !data && (
-        <div className="absolute inset-0 flex items-center justify-center text-gray-500">Loading...</div>
+        <div className="absolute inset-0 flex items-center justify-center text-[var(--muted-foreground)]">Loading...</div>
       )}
 
       {/* Notable Relatives Panel */}
       {data && data.notableRelatives.length > 0 && (
         <div className="absolute top-4 right-4 z-40">
-          <div className="bg-white rounded-lg shadow-lg border border-amber-300 overflow-hidden max-w-xs">
+          <div className="bg-[var(--card)] rounded-lg shadow-lg border border-amber-300 overflow-hidden max-w-xs">
             <Button
               variant="ghost"
               onClick={(e) => { e.stopPropagation(); setNotablePanelOpen(!notablePanelOpen); }}
@@ -1295,8 +1295,8 @@ export default function FamilyTree({ rootPersonId, showAncestors, onPersonClick,
                     className="w-full px-3 py-2 justify-start hover:bg-amber-50 border-t border-amber-100 text-sm rounded-none h-auto"
                   >
                     <div className="text-left">
-                      <div className="font-medium text-gray-800">{rel.person.name_full}</div>
-                      <div className="text-xs text-gray-500">{rel.generation} generation{rel.generation !== 1 ? 's' : ''} away</div>
+                      <div className="font-medium text-[var(--foreground)]">{rel.person.name_full}</div>
+                      <div className="text-xs text-[var(--muted-foreground)]">{rel.generation} generation{rel.generation !== 1 ? 's' : ''} away</div>
                     </div>
                   </Button>
                 ))}
@@ -1309,16 +1309,16 @@ export default function FamilyTree({ rootPersonId, showAncestors, onPersonClick,
       {/* Priority/Status Popup */}
       {priorityPopup && (
         <div
-          className="absolute bg-white rounded-lg shadow-xl border p-3 z-50"
+          className="absolute bg-[var(--card)] text-[var(--card-foreground)] rounded-lg shadow-xl border border-[var(--border)] p-3 z-50"
           style={{ left: priorityPopup.x, top: priorityPopup.y }}
           onClick={(e) => e.stopPropagation()}
         >
           <div className="font-semibold text-sm mb-2 truncate max-w-48">{priorityPopup.personName}</div>
 
           <div className="mb-3">
-            <label className="text-xs font-medium text-gray-600 flex items-center gap-1">
+            <label className="text-xs font-medium text-[var(--muted-foreground)] flex items-center gap-1">
               Priority
-              <span className="text-gray-400 cursor-help" title="0 = No urgency, 10 = Research immediately. Higher priority people appear first in research queue.">ⓘ</span>
+              <span className="text-[var(--muted-foreground)] cursor-help" title="0 = No urgency, 10 = Research immediately. Higher priority people appear first in research queue.">ⓘ</span>
             </label>
             <div className="flex items-center gap-2 mt-1">
               <input
@@ -1335,7 +1335,7 @@ export default function FamilyTree({ rootPersonId, showAncestors, onPersonClick,
               />
               <span className="text-sm font-bold w-6">{priorityPopup.priority}</span>
             </div>
-            <div className="text-[10px] text-gray-400 mt-0.5">
+            <div className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
               {priorityPopup.priority === 0 ? 'Not prioritized' :
                priorityPopup.priority <= 3 ? 'Low priority' :
                priorityPopup.priority <= 6 ? 'Medium priority' :
@@ -1344,9 +1344,9 @@ export default function FamilyTree({ rootPersonId, showAncestors, onPersonClick,
           </div>
 
           <div>
-            <Label className="text-xs font-medium text-gray-600 flex items-center gap-1">
+            <Label className="text-xs font-medium text-[var(--muted-foreground)] flex items-center gap-1">
               Status
-              <span className="text-gray-400 cursor-help" title="Tracks research progress: Not Started → In Progress → Partial/Verified. Use Brick Wall when stuck.">ⓘ</span>
+              <span className="text-[var(--muted-foreground)] cursor-help" title="Tracks research progress: Not Started → In Progress → Partial/Verified. Use Brick Wall when stuck.">ⓘ</span>
             </Label>
             <Select
               value={priorityPopup.status}
@@ -1364,13 +1364,13 @@ export default function FamilyTree({ rootPersonId, showAncestors, onPersonClick,
                 ))}
               </SelectContent>
             </Select>
-            <div className="text-[10px] text-gray-400 mt-0.5">
+            <div className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
               {STATUS_OPTIONS.find(s => s.value === priorityPopup.status)?.desc}
             </div>
           </div>
 
           <div className="mt-2 text-right">
-            <Button variant="link" size="sm" onClick={() => setPriorityPopup(null)} className="text-xs text-gray-500 hover:text-gray-700">
+            <Button variant="link" size="sm" onClick={() => setPriorityPopup(null)} className="text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)]">
               Close
             </Button>
           </div>
@@ -1383,7 +1383,7 @@ export default function FamilyTree({ rootPersonId, showAncestors, onPersonClick,
           className="absolute pointer-events-none z-50"
           style={{ left: crestPopup.x, top: crestPopup.y }}
         >
-          <div className="bg-white rounded-lg shadow-xl border-2 border-amber-400 p-2">
+          <div className="bg-[var(--card)] rounded-lg shadow-xl border-2 border-amber-400 p-2">
             <div className="relative w-36 h-36">
               <Image
                 src={crestPopup.url}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -12,15 +12,15 @@ export default function Footer() {
         <div>
           <p>© {new Date().getFullYear()} {settings.family_name} {settings.site_name}</p>
           {settings.footer_text && (
-            <p className="text-sm text-gray-500 mt-1">{settings.footer_text}</p>
+            <p className="text-sm text-[var(--muted-foreground)] mt-1">{settings.footer_text}</p>
           )}
           {settings.admin_email && (
-            <p className="text-sm text-gray-500 mt-1">
+            <p className="text-sm text-[var(--muted-foreground)] mt-1">
               Contact: <a href={`mailto:${settings.admin_email}`} className="hover:underline">{settings.admin_email}</a>
             </p>
           )}
         </div>
-        <div className="flex items-center gap-1.5 text-xs text-gray-400">
+        <div className="flex items-center gap-1.5 text-xs text-[var(--muted-foreground)]">
           <span>Powered by</span>
           <Image src="/kindred-logo.svg" alt="Kindred" width={16} height={16} className="opacity-60" unoptimized />
           <span className="font-medium">Kindred</span>

--- a/components/GlobalSearch.tsx
+++ b/components/GlobalSearch.tsx
@@ -85,19 +85,19 @@ export default function GlobalSearch() {
 
       {/* Dropdown results */}
       {isOpen && (
-        <div className="absolute top-full mt-2 w-72 bg-white rounded-lg shadow-xl border z-50 max-h-80 overflow-y-auto">
+        <div className="absolute top-full mt-2 w-72 bg-[var(--card)] text-[var(--card-foreground)] rounded-lg shadow-xl border border-[var(--border)] z-50 max-h-80 overflow-y-auto">
           {loading ? (
-            <div className="p-4 text-center text-gray-500 text-sm">Searching...</div>
+            <div className="p-4 text-center text-[var(--muted-foreground)] text-sm">Searching...</div>
           ) : results.length > 0 ? (
             <>
               {results.map((person) => (
                 <button
                   key={person.id}
                   onClick={() => handleSelect(person.id)}
-                  className="w-full px-4 py-3 text-left hover:bg-gray-50 border-b last:border-b-0 transition-colors"
+                  className="w-full px-4 py-3 text-left hover:bg-[var(--accent)] border-b border-[var(--border)] last:border-b-0 transition-colors"
                 >
-                  <div className="font-medium text-gray-900">{person.name_full}</div>
-                  <div className="text-xs text-gray-500">
+                  <div className="font-medium">{person.name_full}</div>
+                  <div className="text-xs text-[var(--muted-foreground)]">
                     {person.birth_year && `b. ${person.birth_year}`}
                     {person.birth_year && person.death_year && ' – '}
                     {person.death_year && `d. ${person.death_year}`}
@@ -108,14 +108,14 @@ export default function GlobalSearch() {
               {data?.search?.totalCount && data.search.totalCount > 8 && (
                 <button
                   onClick={() => { router.push(`/search?q=${encodeURIComponent(query)}`); setIsFocused(false); }}
-                  className="w-full px-4 py-2 text-center text-sm text-blue-600 hover:bg-blue-50"
+                  className="w-full px-4 py-2 text-center text-sm text-blue-600 dark:text-blue-400 hover:bg-[var(--accent)]"
                 >
                   View all {data.search.totalCount} results →
                 </button>
               )}
             </>
           ) : query.length >= 2 ? (
-            <div className="p-4 text-center text-gray-500 text-sm">No results found</div>
+            <div className="p-4 text-center text-[var(--muted-foreground)] text-sm">No results found</div>
           ) : null}
         </div>
       )}


### PR DESCRIPTION
Replace hardcoded Tailwind colors (gray-500, white, etc.) with CSS variables for proper dark mode support.

## Changes
- **CreatePersonModal**: Use --card, --card-foreground, --muted-foreground, --border
- **EditPersonModal**: Use --card, --card-foreground, --muted-foreground, --border
- **FactsEditor**: Use --muted-foreground, --foreground
- **FamilyEditor**: Use --muted-foreground, add dark mode variants for spouse cards
- **FamilyTree**: Use --card, --muted-foreground, --foreground, --border for popups
- **Footer**: Use --muted-foreground
- **GlobalSearch**: Use --card, --muted-foreground, --accent, --border for dropdown

Closes #128