### PR TITLE
feat: add recent searches and keyboard navigation to global search

### DIFF
--- a/components/GlobalSearch.tsx
+++ b/components/GlobalSearch.tsx
@@ -3,9 +3,10 @@
 import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useLazyQuery } from '@apollo/client/react';
-import { Search, X } from 'lucide-react';
+import { Search, X, Clock, Trash2 } from 'lucide-react';
 import { SEARCH_PEOPLE } from '@/lib/graphql/queries';
 import { Person } from '@/lib/types';
+import { useRecentSearches } from '@/lib/hooks/useRecentSearches';
 
 interface SearchResult {
   search: {
@@ -18,9 +19,11 @@ export default function GlobalSearch() {
   const router = useRouter();
   const [query, setQuery] = useState('');
   const [isFocused, setIsFocused] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
   const [executeSearch, { data, loading }] = useLazyQuery<SearchResult>(SEARCH_PEOPLE);
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const { searches: recentSearches, addSearch, clearSearches } = useRecentSearches();
 
   const results = data?.search?.edges?.map(e => e.node) || [];
 
@@ -31,8 +34,23 @@ export default function GlobalSearch() {
     }
   }, [query, executeSearch]);
 
-  // Dropdown open state derived from query length and focus
-  const isOpen = query.length >= 2 && isFocused;
+  // Handle query change - reset selection
+  const handleQueryChange = (newQuery: string) => {
+    setQuery(newQuery);
+    setSelectedIndex(-1);
+  };
+
+  // Show dropdown when focused and either has query or has recent searches
+  const showResults = query.length >= 2 && isFocused;
+  const showRecent = isFocused && query.length < 2 && recentSearches.length > 0;
+  const isOpen = showResults || showRecent;
+
+  // Calculate total items for keyboard navigation
+  const totalItems = showRecent
+    ? recentSearches.length
+    : showResults
+      ? results.length + (data?.search?.totalCount && data.search.totalCount > 8 ? 1 : 0)
+      : 0;
 
   // Close on click outside
   useEffect(() => {
@@ -51,14 +69,47 @@ export default function GlobalSearch() {
     router.push(`/person/${personId}`);
   };
 
+  const handleRecentClick = (searchQuery: string) => {
+    addSearch(searchQuery);
+    setIsFocused(false);
+    router.push(`/search?q=${encodeURIComponent(searchQuery)}`);
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       setQuery('');
+      setSelectedIndex(-1);
       inputRef.current?.blur();
-    } else if (e.key === 'Enter' && query.trim()) {
-      // Navigate to full search page on Enter
-      setIsFocused(false);
-      router.push(`/search?q=${encodeURIComponent(query.trim())}`);
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (isOpen && totalItems > 0) {
+        setSelectedIndex(prev => (prev + 1) % totalItems);
+      }
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (isOpen && totalItems > 0) {
+        setSelectedIndex(prev => (prev - 1 + totalItems) % totalItems);
+      }
+    } else if (e.key === 'Enter') {
+      if (selectedIndex >= 0 && isOpen) {
+        e.preventDefault();
+        if (showRecent && selectedIndex < recentSearches.length) {
+          handleRecentClick(recentSearches[selectedIndex].query);
+        } else if (showResults) {
+          if (selectedIndex < results.length) {
+            addSearch(query);
+            handleSelect(results[selectedIndex].id);
+          } else {
+            addSearch(query);
+            router.push(`/search?q=${encodeURIComponent(query)}`);
+            setIsFocused(false);
+          }
+        }
+      } else if (query.trim()) {
+        addSearch(query.trim());
+        setIsFocused(false);
+        router.push(`/search?q=${encodeURIComponent(query.trim())}`);
+      }
     }
   };
 
@@ -70,53 +121,90 @@ export default function GlobalSearch() {
           ref={inputRef}
           type="text"
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => handleQueryChange(e.target.value)}
           onFocus={() => setIsFocused(true)}
           onKeyDown={handleKeyDown}
           placeholder="Search people..."
           className="bg-transparent text-white placeholder-white/50 px-3 py-2 w-48 focus:w-64 transition-all outline-none text-sm"
         />
         {query && (
-          <button onClick={() => setQuery('')} className="pr-3 text-white/60 hover:text-white">
+          <button onClick={() => handleQueryChange('')} className="pr-3 text-white/60 hover:text-white">
             <X className="w-4 h-4" />
           </button>
         )}
       </div>
 
-      {/* Dropdown results */}
+      {/* Dropdown */}
       {isOpen && (
         <div className="absolute top-full mt-2 w-72 bg-[var(--card)] text-[var(--card-foreground)] rounded-lg shadow-xl border border-[var(--border)] z-50 max-h-80 overflow-y-auto">
-          {loading ? (
-            <div className="p-4 text-center text-[var(--muted-foreground)] text-sm">Searching...</div>
-          ) : results.length > 0 ? (
+          {/* Recent searches (when no query) */}
+          {showRecent && (
             <>
-              {results.map((person) => (
+              <div className="px-4 py-2 flex items-center justify-between border-b border-[var(--border)]">
+                <span className="text-xs font-medium text-[var(--muted-foreground)] flex items-center gap-1">
+                  <Clock className="w-3 h-3" /> Recent Searches
+                </span>
                 <button
-                  key={person.id}
-                  onClick={() => handleSelect(person.id)}
-                  className="w-full px-4 py-3 text-left hover:bg-[var(--accent)] border-b border-[var(--border)] last:border-b-0 transition-colors"
+                  onClick={(e) => { e.stopPropagation(); clearSearches(); }}
+                  className="text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] flex items-center gap-1"
                 >
-                  <div className="font-medium">{person.name_full}</div>
-                  <div className="text-xs text-[var(--muted-foreground)]">
-                    {person.birth_year && `b. ${person.birth_year}`}
-                    {person.birth_year && person.death_year && ' – '}
-                    {person.death_year && `d. ${person.death_year}`}
-                    {person.birth_place && ` • ${person.birth_place}`}
-                  </div>
+                  <Trash2 className="w-3 h-3" /> Clear
+                </button>
+              </div>
+              {recentSearches.map((search, index) => (
+                <button
+                  key={search.timestamp}
+                  onClick={() => handleRecentClick(search.query)}
+                  className={`w-full px-4 py-2 text-left border-b border-[var(--border)] last:border-b-0 transition-colors flex items-center gap-2 ${
+                    selectedIndex === index ? 'bg-[var(--accent)]' : 'hover:bg-[var(--accent)]'
+                  }`}
+                >
+                  <Clock className="w-3 h-3 text-[var(--muted-foreground)]" />
+                  <span className="text-sm">{search.query}</span>
                 </button>
               ))}
-              {data?.search?.totalCount && data.search.totalCount > 8 && (
-                <button
-                  onClick={() => { router.push(`/search?q=${encodeURIComponent(query)}`); setIsFocused(false); }}
-                  className="w-full px-4 py-2 text-center text-sm text-blue-600 dark:text-blue-400 hover:bg-[var(--accent)]"
-                >
-                  View all {data.search.totalCount} results →
-                </button>
+            </>
+          )}
+          {/* Search results */}
+          {showResults && (
+            <>
+              {loading ? (
+                <div className="p-4 text-center text-[var(--muted-foreground)] text-sm">Searching...</div>
+              ) : results.length > 0 ? (
+                <>
+                  {results.map((person, index) => (
+                    <button
+                      key={person.id}
+                      onClick={() => { addSearch(query); handleSelect(person.id); }}
+                      className={`w-full px-4 py-3 text-left border-b border-[var(--border)] last:border-b-0 transition-colors ${
+                        selectedIndex === index ? 'bg-[var(--accent)]' : 'hover:bg-[var(--accent)]'
+                      }`}
+                    >
+                      <div className="font-medium">{person.name_full}</div>
+                      <div className="text-xs text-[var(--muted-foreground)]">
+                        {person.birth_year && `b. ${person.birth_year}`}
+                        {person.birth_year && person.death_year && ' – '}
+                        {person.death_year && `d. ${person.death_year}`}
+                        {person.birth_place && ` • ${person.birth_place}`}
+                      </div>
+                    </button>
+                  ))}
+                  {data?.search?.totalCount && data.search.totalCount > 8 && (
+                    <button
+                      onClick={() => { addSearch(query); router.push(`/search?q=${encodeURIComponent(query)}`); setIsFocused(false); }}
+                      className={`w-full px-4 py-2 text-center text-sm text-blue-600 dark:text-blue-400 ${
+                        selectedIndex === results.length ? 'bg-[var(--accent)]' : 'hover:bg-[var(--accent)]'
+                      }`}
+                    >
+                      View all {data.search.totalCount} results →
+                    </button>
+                  )}
+                </>
+              ) : (
+                <div className="p-4 text-center text-[var(--muted-foreground)] text-sm">No results found</div>
               )}
             </>
-          ) : query.length >= 2 ? (
-            <div className="p-4 text-center text-[var(--muted-foreground)] text-sm">No results found</div>
-          ) : null}
+          )}
         </div>
       )}
     </div>

--- a/lib/hooks/useRecentSearches.ts
+++ b/lib/hooks/useRecentSearches.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState, useCallback, useSyncExternalStore } from 'react';
+
+const STORAGE_KEY = 'kindred-recent-searches';
+const MAX_SEARCHES = 10;
+
+export interface RecentSearch {
+  query: string;
+  timestamp: number;
+}
+
+// Helper to get searches from localStorage
+function getStoredSearches(): RecentSearch[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+// Subscribe to storage events for cross-tab sync
+function subscribe(callback: () => void) {
+  window.addEventListener('storage', callback);
+  return () => window.removeEventListener('storage', callback);
+}
+
+export function useRecentSearches() {
+  // Use useSyncExternalStore for localStorage to avoid setState in useEffect
+  const storedSearches = useSyncExternalStore(
+    subscribe,
+    getStoredSearches,
+    () => [] // Server snapshot
+  );
+  
+  // Local state for immediate updates (before storage event fires)
+  const [localSearches, setLocalSearches] = useState<RecentSearch[] | null>(null);
+  
+  // Use local state if set, otherwise use stored
+  const searches = localSearches ?? storedSearches;
+
+  // Add a search to history
+  const addSearch = useCallback((query: string) => {
+    if (!query.trim()) return;
+    
+    const current = getStoredSearches();
+    // Remove duplicates and add new search at the beginning
+    const filtered = current.filter(s => s.query.toLowerCase() !== query.toLowerCase());
+    const updated = [{ query: query.trim(), timestamp: Date.now() }, ...filtered].slice(0, MAX_SEARCHES);
+    
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+    } catch {
+      // Ignore localStorage errors
+    }
+    
+    setLocalSearches(updated);
+  }, []);
+
+  // Remove a specific search
+  const removeSearch = useCallback((query: string) => {
+    const current = getStoredSearches();
+    const updated = current.filter(s => s.query !== query);
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+    } catch {
+      // Ignore localStorage errors
+    }
+    setLocalSearches(updated);
+  }, []);
+
+  // Clear all searches
+  const clearSearches = useCallback(() => {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Ignore localStorage errors
+    }
+    setLocalSearches([]);
+  }, []);
+
+  return {
+    searches,
+    addSearch,
+    removeSearch,
+    clearSearches,
+  };
+}
+


### PR DESCRIPTION
## Summary
Add search enhancements: recent searches history and keyboard navigation.

## Recent Searches (closes #126)
- **useRecentSearches hook**: Custom hook with localStorage persistence
- **Recent searches dropdown**: Shows when search input is focused (before typing)
- **Last 10 searches**: Stores up to 10 recent searches per user
- **Click to re-run**: Click any recent search to execute it
- **Clear history**: Button to clear all recent searches
- **Cross-tab sync**: Uses useSyncExternalStore for proper React 18 external store sync

## Keyboard Navigation (closes #125)
- **Arrow Down/Up**: Navigate through dropdown items
- **Enter**: Select highlighted item (navigates to person or executes search)
- **Escape**: Clear search and close dropdown
- **Visual highlight**: Selected item shows accent background
- Wraps around at list boundaries

## Technical Details
- Uses useSyncExternalStore to avoid setState in useEffect (ESLint compliant)
- Subscribes to storage events for cross-tab synchronization
- Dark mode compatible using CSS variables

Closes #125, closes #126
