### PR TITLE
fix: resolve API key page infinite re-render (React #185)

### DIFF
--- a/app/admin/api-keys/page.tsx
+++ b/app/admin/api-keys/page.tsx
@@ -27,7 +27,11 @@ export default function ApiKeysPage() {
   const [newKey, setNewKey] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
 
-  const { data, loading, refetch } = useQuery<UserData>(GET_ME);
+  // Skip query until session is confirmed
+  const isAuthenticated = status === 'authenticated' && !!session;
+  const { data, loading, refetch } = useQuery<UserData>(GET_ME, {
+    skip: !isAuthenticated,
+  });
   const [generateApiKey, { loading: generating }] = useMutation(GENERATE_API_KEY);
   const [revokeApiKey, { loading: revoking }] = useMutation(REVOKE_API_KEY);
 
@@ -38,7 +42,6 @@ export default function ApiKeysPage() {
     if (status === 'loading') return;
     if (!session) {
       router.push('/');
-      return;
     }
   }, [session, status, router]);
 
@@ -82,7 +85,8 @@ export default function ApiKeysPage() {
     return key.slice(0, 4) + '••••••••••••••••••••••••' + key.slice(-4);
   };
 
-  if (loading) {
+  // Show loading while session or data is loading
+  if (status === 'loading' || loading) {
     return (
       <>
         <PageHeader title="API Keys" subtitle="Manage your API access" icon="Key" />
@@ -91,6 +95,11 @@ export default function ApiKeysPage() {
         </div>
       </>
     );
+  }
+
+  // Don't render if not authenticated (redirect is happening)
+  if (!session) {
+    return null;
   }
 
   return (

--- a/lib/hooks/useRecentSearches.ts
+++ b/lib/hooks/useRecentSearches.ts
@@ -10,12 +10,22 @@ export interface RecentSearch {
   timestamp: number;
 }
 
+// Cache the last result to prevent useSyncExternalStore from thinking data changed
+let lastStored: string | null = null;
+let lastParsed: RecentSearch[] = [];
+
 // Helper to get searches from localStorage
 function getStoredSearches(): RecentSearch[] {
   if (typeof window === 'undefined') return [];
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    return stored ? JSON.parse(stored) : [];
+    // Return cached result if localStorage hasn't changed
+    if (stored === lastStored) {
+      return lastParsed;
+    }
+    lastStored = stored;
+    lastParsed = stored ? JSON.parse(stored) : [];
+    return lastParsed;
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
Fix the React error #185 (maximum update depth exceeded) on the API Key management page.

## Changes
- Skip GraphQL \GET_ME\ query until session is authenticated (prevents query from running before auth is ready)
- Add session loading state check to show spinner during auth check
- Return null while redirect is in progress to avoid rendering during navigation
- Fix \useRecentSearches\ hook to cache localStorage result (prevents useSyncExternalStore infinite loop)

## Root Cause
The component was firing the GraphQL query before session authentication was confirmed, which could cause the auth context to throw and trigger re-renders. Additionally, \useSyncExternalStore\ was getting new array references on each call.

Closes #142