### PR TITLE
fix: fix invitation flow - redirect to accept-invite page

### DIFF
--- a/app/api/graphql/route.ts
+++ b/app/api/graphql/route.ts
@@ -145,8 +145,15 @@ const handler = startServerAndCreateNextHandler<NextRequest, Context>(server, {
 
     // Fall back to NextAuth session
     const session = await auth();
+
+    // Allow unauthenticated access - some mutations like registerWithInvitation,
+    // requestPasswordReset, and resetPassword don't require authentication.
+    // The resolvers themselves check auth where needed via requireAuth().
     if (!session?.user) {
-      throw new Error('Authentication required');
+      return {
+        user: { id: '', email: '', role: 'anonymous' },
+        loaders,
+      };
     }
 
     return {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,15 +1,24 @@
 'use client';
 
 import { signIn } from 'next-auth/react';
-import { useSearchParams } from 'next/navigation';
-import { Suspense, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { Suspense, useState, useEffect } from 'react';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import { Button, Input, Label } from '@/components/ui';
 import { Mail, ArrowLeft } from 'lucide-react';
 
 function LoginContent() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const error = searchParams.get('error');
+  const inviteToken = searchParams.get('invite');
+
+  // Redirect to accept-invite if invite token is present
+  useEffect(() => {
+    if (inviteToken) {
+      router.replace(`/accept-invite?token=${inviteToken}`);
+    }
+  }, [inviteToken, router]);
   const [showEmailLogin, setShowEmailLogin] = useState(false);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -34,6 +43,15 @@ function LoginContent() {
       window.location.href = '/';
     }
   };
+
+  // Show loading while redirecting to accept-invite
+  if (inviteToken) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+        <LoadingSpinner size="lg" className="text-white" message="Preparing invitation..." />
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">


### PR DESCRIPTION
## Summary
Fix the invitation flow that was broken due to URL mismatch and authentication issues.

## Changes
1. **Login page redirect**: When a user clicks an invite link (/login?invite=TOKEN), they are now redirected to /accept-invite?token=TOKEN
2. **GraphQL unauthenticated access**: Allow unauthenticated requests to reach resolvers - the resolvers themselves enforce auth via requireAuth() where needed

## Root Cause
The invitation flow was broken because:
1. Invite emails linked to /login?invite=TOKEN
2. The login page did not handle the invite parameter at all
3. The GraphQL route threw "Authentication required" before resolvers could run, blocking registerWithInvitation mutation

## Testing
- Lint passes
- All 160 tests pass
- Build succeeds

Closes #138

