### PR TITLE
feat: Add user menu dropdown in page header

### DIFF
--- a/__tests__/components/Sidebar.test.tsx
+++ b/__tests__/components/Sidebar.test.tsx
@@ -145,18 +145,6 @@ describe('Sidebar', () => {
       expect(treeLink).toHaveClass('active');
     });
 
-    it('shows user name and email', () => {
-      render(<Sidebar />);
-
-      expect(screen.getByText('Test User')).toBeInTheDocument();
-      expect(screen.getByText('test@test.com')).toBeInTheDocument();
-    });
-
-    it('shows Sign Out button', () => {
-      render(<Sidebar />);
-      expect(screen.getByText('Sign Out')).toBeInTheDocument();
-    });
-
     it('does not show Admin link for non-admin users', () => {
       render(<Sidebar />);
       expect(screen.queryByText('Admin')).not.toBeInTheDocument();
@@ -187,15 +175,15 @@ describe('Sidebar', () => {
   });
 
   describe('when loading', () => {
-    it('shows loading state while session is loading', () => {
+    it('shows Admin link with reduced opacity while session is loading', () => {
       mockedUsePathname.mockReturnValue('/');
       mockedUseSession.mockReturnValue({ data: null, status: 'loading' });
 
       render(<Sidebar />);
 
-      // Should show loading skeleton (animate-pulse div)
-      const loadingDiv = document.querySelector('.animate-pulse');
-      expect(loadingDiv).toBeInTheDocument();
+      // Admin link should be visible but with reduced opacity during loading
+      const adminLink = screen.getByRole('link', { name: /Admin/i });
+      expect(adminLink).toHaveClass('opacity-50');
     });
   });
 

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,7 +6,6 @@ import {
   ChevronRight,
   ClipboardList,
   LayoutDashboard,
-  LogOut,
   type LucideIcon,
   Settings,
   Shield,
@@ -16,7 +15,7 @@ import {
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { signOut, useSession } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 import { Button } from '@/components/ui';
 import { useSettings } from './SettingsProvider';
 import { useSidebar } from './SidebarContext';
@@ -217,64 +216,6 @@ export default function Sidebar() {
           <ChevronLeft className="w-4 h-4" />
         )}
       </Button>
-
-      {/* User section */}
-      <div
-        className={`border-t border-white/10 ${isCollapsed ? 'p-3' : 'p-6'}`}
-      >
-        {isLoading ? (
-          <div className="animate-pulse">
-            <div
-              className={`h-4 bg-gray-700 rounded ${isCollapsed ? 'w-8' : 'w-24'} mb-2`}
-            ></div>
-            {!isCollapsed && (
-              <div className="h-3 bg-gray-700 rounded w-32"></div>
-            )}
-          </div>
-        ) : (
-          session?.user && (
-            <div className={isCollapsed ? 'flex flex-col items-center' : ''}>
-              {/* User avatar */}
-              <div
-                className={`flex items-center ${isCollapsed ? 'justify-center' : 'gap-3'} mb-2`}
-              >
-                <div
-                  className="w-8 h-8 rounded-full bg-gradient-to-br from-green-400 to-green-600
-                            flex items-center justify-center text-white text-sm font-semibold"
-                >
-                  {session.user.name?.charAt(0).toUpperCase() || 'U'}
-                </div>
-                {!isCollapsed && (
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm text-gray-300 truncate">
-                      {session.user.name}
-                    </p>
-                    <p className="text-xs text-gray-500 truncate">
-                      {session.user.email}
-                    </p>
-                  </div>
-                )}
-              </div>
-              {!isCollapsed && (
-                <p className="text-xs text-gray-600 capitalize mb-2">
-                  {session.user.role}
-                </p>
-              )}
-              <Tooltip label="Sign Out" show={isCollapsed}>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => signOut({ callbackUrl: '/login' })}
-                  className={`text-xs text-red-400 hover:text-red-300 ${isCollapsed ? 'p-2' : ''}`}
-                  icon={<LogOut className="w-3.5 h-3.5" />}
-                >
-                  {!isCollapsed && 'Sign Out'}
-                </Button>
-              </Tooltip>
-            </div>
-          )
-        )}
-      </div>
     </nav>
   );
 }

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { Key, LogOut, Settings, Shield, User, Users } from 'lucide-react';
+import Link from 'next/link';
+import { signOut, useSession } from 'next-auth/react';
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './ui';
+
+export default function UserMenu() {
+  const { data: session, status } = useSession();
+
+  // Don't render during loading or if not authenticated
+  if (status === 'loading' || status === 'unauthenticated' || !session?.user) {
+    return null;
+  }
+
+  const user = session.user;
+  const isAdmin = user.role === 'admin';
+  const initials =
+    user.name
+      ?.split(' ')
+      .map((n) => n[0])
+      .join('')
+      .toUpperCase()
+      .slice(0, 2) || 'U';
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-2 rounded-full focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-transparent"
+        >
+          <Avatar className="h-9 w-9 border-2 border-white/30 hover:border-white/50 transition-colors cursor-pointer">
+            {user.image && (
+              <AvatarImage src={user.image} alt={user.name || 'User'} />
+            )}
+            <AvatarFallback className="bg-gradient-to-br from-green-400 to-green-600 text-white text-sm font-semibold">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56" align="end" sideOffset={8}>
+        {/* User Info */}
+        <DropdownMenuLabel className="font-normal">
+          <div className="flex flex-col space-y-1">
+            <p className="text-sm font-medium leading-none">{user.name}</p>
+            <p className="text-xs leading-none text-muted-foreground">
+              {user.email}
+            </p>
+            <p className="text-xs leading-none text-muted-foreground capitalize pt-1">
+              Role: {user.role}
+            </p>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+
+        {/* Admin Links - Only for admins */}
+        {isAdmin && (
+          <>
+            <DropdownMenuGroup>
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                Administration
+              </DropdownMenuLabel>
+              <DropdownMenuItem asChild>
+                <Link href="/admin" className="cursor-pointer">
+                  <Shield className="mr-2 h-4 w-4" />
+                  <span>Admin Dashboard</span>
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/admin#users" className="cursor-pointer">
+                  <Users className="mr-2 h-4 w-4" />
+                  <span>User Management</span>
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/admin#invitations" className="cursor-pointer">
+                  <User className="mr-2 h-4 w-4" />
+                  <span>Invitations</span>
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/admin/api-keys" className="cursor-pointer">
+                  <Key className="mr-2 h-4 w-4" />
+                  <span>API Keys</span>
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/admin/settings" className="cursor-pointer">
+                  <Settings className="mr-2 h-4 w-4" />
+                  <span>Settings</span>
+                </Link>
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+          </>
+        )}
+
+        {/* Sign Out */}
+        <DropdownMenuItem
+          className="cursor-pointer text-red-600 focus:text-red-600 focus:bg-red-50"
+          onClick={() => signOut({ callbackUrl: '/login' })}
+        >
+          <LogOut className="mr-2 h-4 w-4" />
+          <span>Sign Out</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/ui/PageHeader.tsx
+++ b/components/ui/PageHeader.tsx
@@ -20,6 +20,7 @@ import {
 import type { ReactNode } from 'react';
 import GlobalSearch from '../GlobalSearch';
 import { useSettings } from '../SettingsProvider';
+import UserMenu from '../UserMenu';
 
 // Map of icon names to components (for Server → Client serialization)
 const iconMap = {
@@ -97,6 +98,7 @@ export function PageHeader({
         <div className="page-header-actions flex items-center gap-4">
           {showSearch && <GlobalSearch />}
           {actions}
+          <UserMenu />
         </div>
       </div>
 


### PR DESCRIPTION
Adds a user avatar dropdown menu in the page header with quick access to user info and admin functions.

## Changes
- Add \UserMenu\ component with avatar trigger and dropdown
- Show user name, email, and role in dropdown
- Show admin links (Dashboard, Users, Invitations, API Keys, Settings) for admins only
- Move Sign Out from sidebar to dropdown
- Remove redundant user section from Sidebar

## Screenshot Preview
The user avatar appears to the right of the search bar in the page header. Clicking it opens a dropdown with user info and navigation options.

Closes #146