### PR TITLE
perf: Optimize Docker build with BuildKit cache mounts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,48 @@
+# Dependencies
 node_modules
+
+# Build output
 .next
+out
+coverage
+
+# Version control
 .git
 .gitignore
+
+# Documentation
 README.md
+CONTRIBUTING.md
+LICENSE
+*.md
+
+# Docker
 Dockerfile
 .dockerignore
+
+# IDE/Editor
+.vscode
+.idea
+*.swp
+*.swo
+
+# Testing
+__tests__
+*.test.ts
+*.test.tsx
+*.spec.ts
+*.spec.tsx
+vitest.config.mts
+vitest.setup.tsx
+
+# Development
+.env
+.env.local
+.env.*.local
+.eslintrc*
+.prettierrc*
+biome.json
+
+# CI/CD
+.github
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
+# syntax=docker/dockerfile:1
 FROM node:20-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci
+# Use BuildKit cache mount for npm cache
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 # Build the application
 FROM base AS builder
@@ -19,7 +21,8 @@ ENV NEXTAUTH_URL=${NEXTAUTH_URL}
 
 # Do NOT set DATABASE_URL here - it must only exist at runtime
 
-RUN npm run build
+# Use BuildKit cache mount for Next.js build cache
+RUN --mount=type=cache,target=/app/.next/cache npm run build
 
 # Production image
 FROM base AS runner


### PR DESCRIPTION
Optimizes Docker build times with BuildKit cache mounts.

## Changes

### Dockerfile
- Add BuildKit syntax directive for cache mount support
- Cache npm dependencies at /root/.npm between builds
- Cache Next.js build cache at /app/.next/cache between builds

### .dockerignore
- Exclude test files and directories
- Exclude documentation (*.md files)
- Exclude IDE/editor files
- Exclude CI/CD configuration
- Exclude development config files

## Expected Results
On cache-hit builds, these optimizations can save 1-2+ minutes by reusing npm packages and Next.js compilation cache.

Closes #157