### PR TITLE
chore: Enable Biome strict rules as warnings

### DIFF
--- a/__tests__/components/LoadingSpinner.test.tsx
+++ b/__tests__/components/LoadingSpinner.test.tsx
@@ -20,37 +20,41 @@ describe('LoadingSpinner', () => {
 
   it('applies small size class', () => {
     render(<LoadingSpinner size="sm" />);
-    const spinner = screen.getByRole('status');
+    const container = screen.getByRole('status');
+    const spinner = container.querySelector('div');
     expect(spinner).toHaveClass('w-6', 'h-6');
   });
 
   it('applies medium size class (default)', () => {
     render(<LoadingSpinner />);
-    const spinner = screen.getByRole('status');
+    const container = screen.getByRole('status');
+    const spinner = container.querySelector('div');
     expect(spinner).toHaveClass('w-10', 'h-10');
   });
 
   it('applies large size class', () => {
     render(<LoadingSpinner size="lg" />);
-    const spinner = screen.getByRole('status');
+    const container = screen.getByRole('status');
+    const spinner = container.querySelector('div');
     expect(spinner).toHaveClass('w-16', 'h-16');
   });
 
   it('applies custom className', () => {
     render(<LoadingSpinner className="custom-class" />);
-    const container = screen.getByRole('status').parentElement;
+    const container = screen.getByRole('status');
     expect(container).toHaveClass('custom-class');
   });
 
   it('has proper accessibility attributes', () => {
     render(<LoadingSpinner />);
-    const spinner = screen.getByRole('status');
-    expect(spinner).toHaveAttribute('aria-label', 'Loading');
+    const container = screen.getByRole('status');
+    expect(container).toHaveAttribute('aria-label', 'Loading');
   });
 
   it('applies animation class', () => {
     render(<LoadingSpinner />);
-    const spinner = screen.getByRole('status');
+    const container = screen.getByRole('status');
+    const spinner = container.querySelector('div');
     expect(spinner).toHaveClass('animate-spin');
   });
 });

--- a/app/accept-invite/page.tsx
+++ b/app/accept-invite/page.tsx
@@ -172,7 +172,11 @@ function AcceptInviteContent() {
               onClick={() => signIn('google', { callbackUrl: '/' })}
               className="w-full bg-white hover:bg-gray-100 text-gray-800 font-semibold py-3 shadow-lg hover:shadow-xl"
             >
-              <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
+              <svg
+                className="w-5 h-5 mr-2"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
                 <path
                   fill="currentColor"
                   d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -49,6 +49,10 @@ interface Invitation {
   accepted_at: string | null;
 }
 
+interface CreateInvitationResult {
+  createInvitation: Invitation;
+}
+
 export default function AdminPage() {
   const { data: session, status } = useSession();
   const router = useRouter();
@@ -117,10 +121,8 @@ export default function AdminPage() {
       const result = await createInvitation({
         variables: { email: newEmail, role: newRole },
       });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const invitation = (result.data as any)?.createInvitation as
-        | Invitation
-        | undefined;
+      const data = result.data as CreateInvitationResult | undefined;
+      const invitation = data?.createInvitation;
       if (invitation?.token) {
         setInviteUrl(
           `${window.location.origin}/login?invite=${invitation.token}`,

--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -369,9 +369,9 @@ export default function SettingsPage() {
                       className="grid grid-cols-3 gap-4 items-start"
                     >
                       <div>
-                        <label className="block font-medium text-gray-700">
+                        <span className="block font-medium text-gray-700">
                           {SETTING_LABELS[row.key] || row.key}
-                        </label>
+                        </span>
                         <p className="text-sm text-gray-500">
                           {row.description}
                         </p>
@@ -576,8 +576,8 @@ export default function SettingsPage() {
                         View errors
                       </summary>
                       <ul className="mt-1 text-xs text-red-600 max-h-32 overflow-y-auto">
-                        {importResult.errors.map((err, i) => (
-                          <li key={i}>{err}</li>
+                        {importResult.errors.map((err) => (
+                          <li key={err}>{err}</li>
                         ))}
                       </ul>
                     </details>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,7 +36,7 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   // Fetch settings server-side (silently falls back to defaults during build)
-  let settings;
+  let settings: Awaited<ReturnType<typeof getSettings>> | undefined;
   try {
     settings = await getSettings();
   } catch {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -81,7 +81,11 @@ function LoginContent() {
               onClick={() => signIn('google', { callbackUrl: '/' })}
               className="w-full bg-white hover:bg-gray-100 text-gray-800 font-semibold py-3 shadow-lg hover:shadow-xl"
             >
-              <svg className="w-5 h-5 mr-2" viewBox="0 0 24 24">
+              <svg
+                className="w-5 h-5 mr-2"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
                 <path
                   fill="currentColor"
                   d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -129,10 +129,14 @@ function SearchContent() {
                 <div className="flex flex-wrap gap-4 items-center">
                   {/* Sort */}
                   <div className="flex items-center gap-2">
-                    <label className="text-sm font-medium text-[var(--text-muted)]">
+                    <label
+                      htmlFor="sort-select"
+                      className="text-sm font-medium text-[var(--text-muted)]"
+                    >
                       Sort:
                     </label>
                     <select
+                      id="sort-select"
                       value={sortBy}
                       onChange={(e) => setSortBy(e.target.value as SortOption)}
                       className="input-field text-sm py-1 px-2"
@@ -150,10 +154,14 @@ function SearchContent() {
 
                   {/* Living Filter */}
                   <div className="flex items-center gap-2">
-                    <label className="text-sm font-medium text-[var(--text-muted)]">
+                    <label
+                      htmlFor="living-select"
+                      className="text-sm font-medium text-[var(--text-muted)]"
+                    >
                       Status:
                     </label>
                     <select
+                      id="living-select"
                       value={livingFilter}
                       onChange={(e) =>
                         setLivingFilter(e.target.value as LivingFilter)
@@ -169,10 +177,14 @@ function SearchContent() {
                   {/* Surname Filter */}
                   {uniqueSurnames.length > 1 && (
                     <div className="flex items-center gap-2">
-                      <label className="text-sm font-medium text-[var(--text-muted)]">
+                      <label
+                        htmlFor="surname-select"
+                        className="text-sm font-medium text-[var(--text-muted)]"
+                      >
                         Surname:
                       </label>
                       <select
+                        id="surname-select"
                         value={surnameFilter}
                         onChange={(e) => setSurnameFilter(e.target.value)}
                         className="input-field text-sm py-1 px-2"
@@ -192,6 +204,7 @@ function SearchContent() {
                     surnameFilter ||
                     sortBy !== 'relevance') && (
                     <button
+                      type="button"
                       onClick={() => {
                         setLivingFilter('all');
                         setSurnameFilter('');

--- a/app/timeline/page.tsx
+++ b/app/timeline/page.tsx
@@ -74,9 +74,9 @@ export default function TimelinePage() {
                     {year}
                   </h3>
                   <div className="space-y-2">
-                    {events.map((event, i) => (
+                    {events.map((event) => (
                       <Link
-                        key={i}
+                        key={`${event.person.id}-${event.type}`}
                         href={`/person/${event.person.id}`}
                         className="flex items-center gap-2 text-sm hover:text-green-700"
                       >

--- a/components/FamilyEditor.tsx
+++ b/components/FamilyEditor.tsx
@@ -327,10 +327,14 @@ export default function FamilyEditor({
             <div className="space-y-3">
               <h3 className="section-title">Add New Family</h3>
               <div>
-                <label className="text-sm text-muted-foreground">
+                <label
+                  htmlFor="spouse-search"
+                  className="text-sm text-muted-foreground"
+                >
                   Spouse (optional)
                 </label>
                 <Input
+                  id="spouse-search"
                   type="text"
                   placeholder="Search for spouse..."
                   value={searchQuery}

--- a/components/GlobalSearch.tsx
+++ b/components/GlobalSearch.tsx
@@ -138,6 +138,7 @@ export default function GlobalSearch() {
         />
         {query && (
           <button
+            type="button"
             onClick={() => handleQueryChange('')}
             className="pr-3 text-white/60 hover:text-white"
           >
@@ -157,6 +158,7 @@ export default function GlobalSearch() {
                   <Clock className="w-3 h-3" /> Recent Searches
                 </span>
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     clearSearches();
@@ -168,6 +170,7 @@ export default function GlobalSearch() {
               </div>
               {recentSearches.map((search, index) => (
                 <button
+                  type="button"
                   key={search.timestamp}
                   onClick={() => handleRecentClick(search.query)}
                   className={`w-full px-4 py-2 text-left border-b border-[var(--border)] last:border-b-0 transition-colors flex items-center gap-2 ${
@@ -192,6 +195,7 @@ export default function GlobalSearch() {
               <>
                 {results.map((person, index) => (
                   <button
+                    type="button"
                     key={person.id}
                     onClick={() => {
                       addSearch(query);
@@ -214,6 +218,7 @@ export default function GlobalSearch() {
                 ))}
                 {data?.search?.totalCount && data.search.totalCount > 8 && (
                   <button
+                    type="button"
                     onClick={() => {
                       addSearch(query);
                       router.push(`/search?q=${encodeURIComponent(query)}`);

--- a/components/LoadingSpinner.tsx
+++ b/components/LoadingSpinner.tsx
@@ -18,17 +18,18 @@ export default function LoadingSpinner({
   };
 
   return (
-    <div
+    <output
       className={`flex flex-col items-center justify-center gap-3 ${className}`}
+      aria-live="polite"
+      aria-label={message || 'Loading'}
     >
       <div
         className={`${sizeClasses[size]} border-gray-200 border-t-green-600 rounded-full animate-spin`}
-        role="status"
-        aria-label="Loading"
+        aria-hidden="true"
       />
       {message && (
         <p className="text-gray-500 text-sm animate-pulse">{message}</p>
       )}
-    </div>
+    </output>
   );
 }


### PR DESCRIPTION
Enables stricter Biome lint rules as warnings and fixes initial violations.

## Rules Enabled (as warnings)
- **suspicious**: noExplicitAny, noImplicitAnyLet, noArrayIndexKey, noAssignInExpressions, useIterableCallbackReturn
- **style**: noNonNullAssertion
- **a11y**: noSvgWithoutTitle, useButtonType, noLabelWithoutControl, useKeyWithClickEvents, noStaticElementInteractions, useSemanticElements
- **complexity**: noForEach

## Fixes
- Proper types instead of any/implicit any
- Button type attributes on all buttons
- Label/input association with htmlFor/id
- aria-hidden on decorative SVGs
- Semantic output element for LoadingSpinner
- Composite keys instead of array indices

## Remaining Work
49 warnings remain in FamilyTree.tsx and MediaGallery.tsx - tracked by issues #154-156.

## Tests
All 158 tests pass.