### PR TITLE
feat: add estimated dates, placeholder parents, and automatic research queue scoring

### DIFF
--- a/components/ResearchQueueClient.tsx
+++ b/components/ResearchQueueClient.tsx
@@ -36,6 +36,8 @@ interface ResearchPerson {
   research_priority: number | null;
   research_notes_count?: number;
   last_researched?: string | null;
+  research_tip?: string | null;
+  source_count?: number | null;
 }
 
 export default function ResearchQueueClient() {
@@ -114,6 +116,9 @@ export default function ResearchQueueClient() {
                   <th className="py-2 px-3 text-sm font-semibold">Years</th>
                   <th className="py-2 px-3 text-sm font-semibold">Status</th>
                   <th className="py-2 px-3 text-sm font-semibold">
+                    Research Tip
+                  </th>
+                  <th className="py-2 px-3 text-sm font-semibold">
                     Last Researched
                   </th>
                 </tr>
@@ -191,6 +196,16 @@ export default function ResearchQueueClient() {
                             )}
                           </SelectContent>
                         </Select>
+                      </td>
+                      <td className="py-3 px-3 text-sm text-gray-600 max-w-xs">
+                        {person.research_tip ? (
+                          <span className="flex items-start gap-1">
+                            <span className="text-amber-500">💡</span>
+                            <span>{person.research_tip}</span>
+                          </span>
+                        ) : (
+                          <span className="text-gray-400">—</span>
+                        )}
                       </td>
                       <td className="py-3 px-3 text-sm text-gray-500">
                         {person.last_researched

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -504,6 +504,8 @@ export const GET_RESEARCH_QUEUE = gql`
       research_status
       research_priority
       last_researched
+      research_tip
+      source_count
     }
   }
 `;

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -34,6 +34,18 @@ export const typeDefs = `#graphql
     is_notable: Boolean
     notable_description: String
 
+    # Estimated dates and placeholder support (Issue #195)
+    birth_date_accuracy: String
+    birth_year_min: Int
+    birth_year_max: Int
+    death_date_accuracy: String
+    death_year_min: Int
+    death_year_max: Int
+    is_placeholder: Boolean
+
+    # Computed research tip for queue prioritization
+    research_tip: String
+
     # Relationships (batched via DataLoader)
     parents: [Person!]!
     siblings: [Person!]!
@@ -404,6 +416,14 @@ export const typeDefs = `#graphql
     research_priority: Int
     is_notable: Boolean
     notable_description: String
+    # Estimated dates and placeholder support (Issue #195)
+    birth_date_accuracy: String
+    birth_year_min: Int
+    birth_year_max: Int
+    death_date_accuracy: String
+    death_year_min: Int
+    death_year_max: Int
+    is_placeholder: Boolean
   }
 
   input SourceInput {

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -14,6 +14,13 @@ export interface SiteSettings {
   show_coats_of_arms: boolean;
   admin_email: string | null;
   footer_text: string | null;
+  // Research queue scoring weights (Issue #195)
+  research_weight_missing_core_dates: number;
+  research_weight_missing_places: number;
+  research_weight_estimated_dates: number;
+  research_weight_placeholder_parent: number;
+  research_weight_low_sources: number;
+  research_weight_manual_priority: number;
 }
 
 const DEFAULT_SETTINGS: SiteSettings = {
@@ -30,6 +37,13 @@ const DEFAULT_SETTINGS: SiteSettings = {
   show_coats_of_arms: true,
   admin_email: null,
   footer_text: null,
+  // Research queue scoring weights (Issue #195)
+  research_weight_missing_core_dates: 30,
+  research_weight_missing_places: 15,
+  research_weight_estimated_dates: 20,
+  research_weight_placeholder_parent: 40,
+  research_weight_low_sources: 25,
+  research_weight_manual_priority: 10,
 };
 
 // Cache settings for 5 minutes
@@ -69,6 +83,25 @@ export async function getSettings(): Promise<SiteSettings> {
       show_coats_of_arms: dbSettings.show_coats_of_arms !== 'false',
       admin_email: dbSettings.admin_email || null,
       footer_text: dbSettings.footer_text || null,
+      // Research queue scoring weights (Issue #195)
+      research_weight_missing_core_dates:
+        parseInt(dbSettings.research_weight_missing_core_dates, 10) ||
+        DEFAULT_SETTINGS.research_weight_missing_core_dates,
+      research_weight_missing_places:
+        parseInt(dbSettings.research_weight_missing_places, 10) ||
+        DEFAULT_SETTINGS.research_weight_missing_places,
+      research_weight_estimated_dates:
+        parseInt(dbSettings.research_weight_estimated_dates, 10) ||
+        DEFAULT_SETTINGS.research_weight_estimated_dates,
+      research_weight_placeholder_parent:
+        parseInt(dbSettings.research_weight_placeholder_parent, 10) ||
+        DEFAULT_SETTINGS.research_weight_placeholder_parent,
+      research_weight_low_sources:
+        parseInt(dbSettings.research_weight_low_sources, 10) ||
+        DEFAULT_SETTINGS.research_weight_low_sources,
+      research_weight_manual_priority:
+        parseInt(dbSettings.research_weight_manual_priority, 10) ||
+        DEFAULT_SETTINGS.research_weight_manual_priority,
     };
 
     settingsCache = { settings, timestamp: Date.now() };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,6 @@
+// Date accuracy values for estimated dates (Issue #195)
+export type DateAccuracy = 'EXACT' | 'ESTIMATED' | 'RANGE' | 'UNKNOWN';
+
 export interface Person {
   id: string;
   familysearch_id: string | null;
@@ -28,6 +31,16 @@ export interface Person {
   last_researched: string | null;
   is_notable: boolean;
   notable_description: string | null;
+  // Estimated dates and placeholder support (Issue #195)
+  birth_date_accuracy: DateAccuracy | null;
+  birth_year_min: number | null;
+  birth_year_max: number | null;
+  death_date_accuracy: DateAccuracy | null;
+  death_year_min: number | null;
+  death_year_max: number | null;
+  is_placeholder: boolean;
+  // Computed research tip
+  research_tip?: string | null;
 }
 
 // Unified life event (combines residence, occupation, and other events)


### PR DESCRIPTION
## Summary

Implements estimated dates, placeholder parent tracking, and automatic research queue prioritization with configurable scoring and contextual research tips.

## Changes

### Database Migration (v6)
- Added `birth_date_accuracy` / `death_date_accuracy` columns (ENUM: EXACT, ESTIMATED, RANGE, UNKNOWN)
- Added `birth_year_min/max` / `death_year_min/max` for date ranges
- Added `is_placeholder` boolean flag
- Added 6 configurable research scoring weights to settings table

### Automatic Research Queue Scoring
The `researchQueue` resolver now computes an automatic score based on gaps:
- Missing birth/death years (+30 points each)
- Missing birth/death places (+15 points each)
- Estimated/ranged dates (+20 points each)
- Placeholder parents (+40 points)
- No sources attached (+25 points)
- Manual priority boost (x10 multiplier)

All weights are configurable via the settings table.

### Research Tips
Added a computed `research_tip` field on Person that suggests the most helpful next step:
1. Identify unknown father/mother (if placeholder parent exists)
2. Find birth/death record (if year missing)
3. Refine estimated dates (if dates are estimated/ranged)
4. Find location (if places missing)
5. Attach at least one high-quality source (if no sources)
6. Review existing sources (if all gaps filled)

### UI Updates
- Added Research Tip column to the research queue table with lightbulb icon
- Tips are computed on-demand, not stored

### Tests
- Updated researchQueue tests for new scoring logic
- Added comprehensive tests for Person.research_tip resolver

## Verification
- [x] All 166 tests pass
- [x] Lint passes (biome check)
- [x] Build succeeds

Closes #195

