### PR TITLE
feat: Replace Load More buttons with infinite scroll

### DIFF
--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -498,14 +498,24 @@ export const GET_FAMILIES = gql`
 
 export const GET_RESEARCH_QUEUE = gql`
   ${PERSON_CARD_FIELDS}
-  query GetResearchQueue($limit: Int) {
-    researchQueue(limit: $limit) {
-      ...PersonCardFields
-      research_status
-      research_priority
-      last_researched
-      research_tip
-      source_count
+  query GetResearchQueue($first: Int, $after: String) {
+    researchQueue(first: $first, after: $after) {
+      edges {
+        node {
+          ...PersonCardFields
+          research_status
+          research_priority
+          last_researched
+          research_tip
+          source_count
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+        totalCount
+      }
     }
   }
 `;

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -351,7 +351,7 @@ export const typeDefs = `#graphql
 
     # Stats & Research
     stats: Stats!
-    researchQueue(limit: Int): [Person!]!
+    researchQueue(first: Int, after: String): PersonConnection!
 
     # Ancestry traversal (optimized single query)
     ancestors(personId: ID!, generations: Int): [Person!]!

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -1,0 +1,5 @@
+export type {
+  UseInfiniteScrollOptions,
+  UseInfiniteScrollResult,
+} from './useInfiniteScroll';
+export { useInfiniteScroll } from './useInfiniteScroll';

--- a/lib/hooks/useInfiniteScroll.ts
+++ b/lib/hooks/useInfiniteScroll.ts
@@ -1,0 +1,125 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseInfiniteScrollOptions {
+  /**
+   * Whether there are more items to load
+   */
+  hasNextPage: boolean;
+  /**
+   * Whether a fetch is currently in progress
+   */
+  loading: boolean;
+  /**
+   * Function to call when more items should be loaded
+   */
+  onLoadMore: () => void;
+  /**
+   * Threshold in pixels before the end of the container to trigger load
+   * @default 200
+   */
+  threshold?: number;
+  /**
+   * Whether infinite scroll is enabled
+   * @default true
+   */
+  enabled?: boolean;
+}
+
+export interface UseInfiniteScrollResult {
+  /**
+   * Ref to attach to the sentinel element at the end of the list
+   */
+  sentinelRef: React.RefCallback<HTMLElement>;
+  /**
+   * Whether content is currently being loaded
+   */
+  isLoading: boolean;
+}
+
+/**
+ * Hook for implementing infinite scroll using IntersectionObserver.
+ *
+ * Usage:
+ * ```tsx
+ * const { sentinelRef, isLoading } = useInfiniteScroll({
+ *   hasNextPage,
+ *   loading,
+ *   onLoadMore: () => fetchMore({ variables: { after: endCursor } }),
+ * });
+ *
+ * return (
+ *   <div>
+ *     {items.map(item => <Item key={item.id} />)}
+ *     <div ref={sentinelRef} />
+ *     {isLoading && <Spinner />}
+ *   </div>
+ * );
+ * ```
+ */
+export function useInfiniteScroll({
+  hasNextPage,
+  loading,
+  onLoadMore,
+  threshold = 200,
+  enabled = true,
+}: UseInfiniteScrollOptions): UseInfiniteScrollResult {
+  const [isLoading, setIsLoading] = useState(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const loadMoreRef = useRef(onLoadMore);
+
+  // Keep onLoadMore ref up to date
+  useEffect(() => {
+    loadMoreRef.current = onLoadMore;
+  }, [onLoadMore]);
+
+  // Sync isLoading with external loading state
+  useEffect(() => {
+    if (!loading) {
+      setIsLoading(false);
+    }
+  }, [loading]);
+
+  const sentinelRef = useCallback(
+    (node: HTMLElement | null) => {
+      // Cleanup previous observer
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
+      }
+
+      // Don't observe if disabled or no more pages
+      if (!enabled || !hasNextPage || !node) {
+        return;
+      }
+
+      observerRef.current = new IntersectionObserver(
+        (entries) => {
+          const [entry] = entries;
+          if (entry.isIntersecting && !loading && hasNextPage) {
+            setIsLoading(true);
+            loadMoreRef.current();
+          }
+        },
+        {
+          rootMargin: `${threshold}px`,
+        },
+      );
+
+      observerRef.current.observe(node);
+    },
+    [enabled, hasNextPage, loading, threshold],
+  );
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+      }
+    };
+  }, []);
+
+  return { sentinelRef, isLoading };
+}


### PR DESCRIPTION
## Summary

Replaces "Load More" buttons with infinite scroll using IntersectionObserver for a smoother user experience.

## Changes

### New Hook
- `lib/hooks/useInfiniteScroll.ts` - Reusable infinite scroll hook using IntersectionObserver

### GraphQL Changes
- `researchQueue` now returns `PersonConnection` with cursor-based pagination
- Cursor format: base64-encoded "score:id" for stable pagination through score-ordered results

### UI Updates
- **People page**: Removed Load More button, added invisible sentinel that triggers loading
- **Research Queue**: Converted to cursor-based pagination with infinite scroll

### Tests
- Updated resolver tests for new `researchQueue` signature (returns PersonConnection instead of array)

## How It Works

1. A sentinel div is placed at the bottom of the list
2. IntersectionObserver watches when sentinel enters viewport (with 200px threshold)
3. When visible + hasNextPage + not loading, triggers fetchMore
4. New items merge into existing list seamlessly

## Verification
- [x] Lint passes (biome check)
- [x] All 167 tests pass
- [x] Build succeeds

Closes #190

