### PR TITLE
fix: speed up App Runner deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js with cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -139,7 +145,7 @@ jobs:
               --tags Key=Project,Value=genealogy Key=Environment,Value=production
           else
             echo "Waiting for service to be ready and starting deployment..."
-            MAX_ATTEMPTS=60
+            MAX_ATTEMPTS=120  # 10 minutes max (120 x 5s)
             DEPLOYED=false
 
             for i in $(seq 1 $MAX_ATTEMPTS); do
@@ -158,8 +164,7 @@ jobs:
                 fi
               fi
 
-              echo "Waiting 10s before next attempt..."
-              sleep 10
+              sleep 5
             done
 
             if [ "$DEPLOYED" != "true" ]; then
@@ -173,7 +178,7 @@ jobs:
           SERVICE_ARN=$(aws apprunner list-services --query "ServiceSummaryList[?ServiceName=='genealogy-frontend'].ServiceArn" --output text)
           echo "Waiting for deployment to complete..."
 
-          MAX_WAIT=60  # 10 minutes max (60 x 10s)
+          MAX_WAIT=120  # 10 minutes max (120 x 5s)
           for i in $(seq 1 $MAX_WAIT); do
             STATUS=$(aws apprunner describe-service --service-arn "$SERVICE_ARN" --query 'Service.Status' --output text)
             echo "[$i/$MAX_WAIT] Service status: $STATUS"
@@ -200,7 +205,7 @@ jobs:
               exit 1
             fi
 
-            sleep 10
+            sleep 5
           done
 
           echo "❌ Timeout waiting for deployment to complete"


### PR DESCRIPTION
## Summary
Speed up App Runner deployments with caching and faster polling.

## Changes
- **Add GitHub Actions npm cache** - Uses \setup-node\ with \cache: 'npm'\ to cache npm dependencies between workflow runs (~30-60s savings)
- **Reduce polling intervals** - Changed from 10s to 5s for both service-ready and deployment-wait loops (faster status detection)
- **Adjust max attempts** - Doubled to 120 to maintain same 10-minute timeout window

## Expected Improvement
~1-2 minutes faster deployments on average.

## Testing
- No code changes, only workflow configuration
- Will be validated on first deployment after merge
