### PR TITLE
fix: replace node:crypto with Web Crypto API

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -79,10 +79,14 @@ async function bootstrapAdminUser(
 
     // Create admin user
     const bcrypt = await import('bcryptjs');
-    const crypto = await import('node:crypto');
 
     const passwordHash = await bcrypt.hash(initialPassword, 12);
-    const userId = crypto.randomBytes(8).toString('hex');
+    // Use Web Crypto API instead of node:crypto for Edge Runtime compatibility
+    const bytes = new Uint8Array(8);
+    crypto.getRandomValues(bytes);
+    const userId = Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
 
     await pool.query(
       `INSERT INTO users (id, email, name, role, password_hash, auth_provider, require_password_change, created_at)


### PR DESCRIPTION
## Summary

Replace `node:crypto` with Web Crypto API to eliminate Edge Runtime compatibility warning during build.

## Changes

- Use `crypto.getRandomValues()` instead of `crypto.randomBytes()` in `instrumentation.ts`
- Generates same 16-character hex ID for bootstrap admin user

## Before

```
A Node.js module is loaded (node:crypto at line 82) which is not supported in the Edge Runtime.
```

## After

Build completes without node:crypto warning.

## Testing

- `npm run lint` - passes
- `npm run build` - succeeds without warning

Fixes #198

