### PR TITLE
feat: tree defaults to logged-in user linked person

### DIFF
--- a/lib/auth-types.ts
+++ b/lib/auth-types.ts
@@ -6,12 +6,14 @@ declare module 'next-auth' {
       email?: string | null;
       image?: string | null;
       role?: string;
+      personId?: string | null;
     };
   }
 
   interface User {
     id?: string;
     role?: string;
+    personId?: string | null;
   }
 }
 
@@ -27,6 +29,7 @@ export interface AppUser {
   invited_at: Date | null;
   created_at: Date;
   last_login: Date | null;
+  person_id: string | null;
 }
 
 export interface Invitation {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -127,12 +127,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     async session({ session }) {
       if (session.user?.email) {
         const userResult = await pool.query(
-          'SELECT id, role FROM users WHERE email = $1',
+          'SELECT id, role, person_id FROM users WHERE email = $1',
           [session.user.email],
         );
         if (userResult.rows.length > 0) {
           session.user.id = userResult.rows[0].id;
           session.user.role = userResult.rows[0].role;
+          session.user.personId = userResult.rows[0].person_id;
 
           // Update last_accessed (throttled to once per minute to reduce DB writes)
           pool
@@ -149,12 +150,13 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     async jwt({ token, user }) {
       if (user?.email) {
         const userResult = await pool.query(
-          'SELECT id, role FROM users WHERE email = $1',
+          'SELECT id, role, person_id FROM users WHERE email = $1',
           [user.email],
         );
         if (userResult.rows.length > 0) {
           token.userId = userResult.rows[0].id;
           token.role = userResult.rows[0].role;
+          token.personId = userResult.rows[0].person_id;
         }
       }
       return token;

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -535,6 +535,11 @@ export const GET_USERS = gql`
       created_at
       last_login
       last_accessed
+      person_id
+      linked_person {
+        id
+        name_full
+      }
     }
   }
 `;
@@ -595,6 +600,29 @@ export const CREATE_LOCAL_USER = gql`
       name
       role
       created_at
+    }
+  }
+`;
+
+export const LINK_USER_TO_PERSON = gql`
+  mutation LinkUserToPerson($userId: ID!, $personId: ID) {
+    linkUserToPerson(userId: $userId, personId: $personId) {
+      id
+      email
+      person_id
+      linked_person {
+        id
+        name_full
+      }
+    }
+  }
+`;
+
+export const SET_MY_PERSON = gql`
+  mutation SetMyPerson($personId: ID) {
+    setMyPerson(personId: $personId) {
+      id
+      person_id
     }
   }
 `;

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -185,6 +185,8 @@ export const typeDefs = `#graphql
     last_login: String
     last_accessed: String
     api_key: String
+    person_id: String
+    linked_person: Person
   }
 
   type Invitation {
@@ -499,6 +501,7 @@ export const typeDefs = `#graphql
     deleteInvitation(id: ID!): Boolean
     createLocalUser(email: String!, name: String!, role: String!, password: String!, requirePasswordChange: Boolean): User!
     updateUserRole(userId: ID!, role: String!): User
+    linkUserToPerson(userId: ID!, personId: ID): User
     deleteUser(userId: ID!): Boolean
 
     # Service account mutations (requires admin role)
@@ -508,6 +511,9 @@ export const typeDefs = `#graphql
     # Settings mutations (requires admin role)
     updateSettings(input: SettingsInput!): SiteSettings!
     runMigrations: MigrationResult!
+
+    # User profile mutations (current user)
+    setMyPerson(personId: ID): User
 
     # API Key mutations (user can manage their own key)
     generateApiKey: String!

--- a/lib/migrations.ts
+++ b/lib/migrations.ts
@@ -300,6 +300,28 @@ export const migrations: Migration[] = [
       return results;
     },
   },
+  {
+    version: 7,
+    name: 'user_person_link',
+    up: async (pool: Pool) => {
+      const results: string[] = [];
+
+      // Add person_id to users table to link users to their person record
+      await pool.query(`
+        ALTER TABLE users
+        ADD COLUMN IF NOT EXISTS person_id VARCHAR(12) REFERENCES people(id) ON DELETE SET NULL
+      `);
+      results.push('Added person_id column to users table');
+
+      // Create index for efficient lookup
+      await pool.query(`
+        CREATE INDEX IF NOT EXISTS idx_users_person_id ON users(person_id)
+      `);
+      results.push('Created index on users.person_id');
+
+      return results;
+    },
+  },
 ];
 
 // Get current database version

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -4,7 +4,7 @@ import { pool } from './pool';
 
 export async function getUsers(): Promise<AppUser[]> {
   const result = await pool.query(
-    `SELECT id, email, name, image, role, invited_by, invited_at, created_at, last_login, last_accessed, api_key FROM users ORDER BY created_at DESC`,
+    `SELECT id, email, name, image, role, invited_by, invited_at, created_at, last_login, last_accessed, api_key, person_id FROM users ORDER BY created_at DESC`,
   );
   return result.rows;
 }
@@ -16,6 +16,16 @@ export async function getUser(id: string): Promise<AppUser | null> {
 
 export async function updateUserRole(id: string, role: string): Promise<void> {
   await pool.query('UPDATE users SET role = $1 WHERE id = $2', [role, id]);
+}
+
+export async function linkUserToPerson(
+  userId: string,
+  personId: string | null,
+): Promise<void> {
+  await pool.query('UPDATE users SET person_id = $1 WHERE id = $2', [
+    personId,
+    userId,
+  ]);
 }
 
 export async function deleteUser(id: string): Promise<void> {

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,33 @@
+import 'next-auth';
+import 'next-auth/jwt';
+
+declare module 'next-auth' {
+  interface Session {
+    user: {
+      id?: string;
+      email?: string | null;
+      name?: string | null;
+      image?: string | null;
+      role?: string;
+      personId?: string | null;
+    };
+  }
+
+  interface User {
+    id?: string;
+    email?: string | null;
+    name?: string | null;
+    image?: string | null;
+    role?: string;
+    personId?: string | null;
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    userId?: string;
+    role?: string;
+    personId?: string | null;
+  }
+}
+


### PR DESCRIPTION
## Summary

Implements user-to-person linking so the tree view defaults to the logged-in user's family tree.

## Changes

### Database
- **Migration 7**: Adds `person_id` column to `users` table with foreign key to `people`

### GraphQL
- `setMyPerson(personId)` mutation - allows users to link themselves to a person record
- `linkUserToPerson(userId, personId)` mutation - admin override
- `person_id` and `linked_person` fields on User type

### UI
- **Person page**: "This is me" button for all authenticated users to self-link
- **Tree page**: Defaults to user's linked person when no URL param provided
- **Admin page**: Shows linked person as clickable link with unlink button (cleaner than dropdown)

### Session
- `personId` now included in session for client-side access

## Testing

- [x] Lint passes
- [x] Build passes
- [ ] Manual test: Click "This is me" on a person page
- [ ] Manual test: Verify tree defaults to linked person
- [ ] Manual test: Admin can unlink users

Closes #188

