### PR TITLE
feat: Enhanced dashboard homepage with activity and research suggestions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,81 +1,293 @@
+import {
+  BookOpen,
+  Calendar,
+  GitBranch,
+  Search,
+  TreePine,
+  UserPlus,
+  Users,
+} from 'lucide-react';
+import Link from 'next/link';
 import PersonCard from '@/components/PersonCard';
 import StatsCard from '@/components/StatsCard';
-import { PageHeader } from '@/components/ui';
-import { GET_RECENT_PEOPLE, GET_STATS } from '@/lib/graphql/queries';
+import { ButtonLink, PageHeader } from '@/components/ui';
+import { GET_DASHBOARD } from '@/lib/graphql/queries';
 import { query } from '@/lib/graphql/server';
-import type { Person, Stats } from '@/lib/types';
+import type { Person } from '@/lib/types';
 
 export const dynamic = 'force-dynamic';
 
-export default async function Home() {
-  const [statsResult, recentResult] = await Promise.all([
-    query<{ stats: Stats }>(GET_STATS),
-    query<{ recentPeople: Person[] }>(GET_RECENT_PEOPLE, { limit: 6 }),
-  ]);
+interface DashboardStats {
+  total_people: number;
+  total_families: number;
+  total_sources: number;
+  total_media: number;
+  earliest_birth: number | null;
+  latest_birth: number | null;
+  living_count: number;
+  incomplete_count: number;
+}
 
-  const stats = statsResult.stats;
-  const recentPeople = recentResult.recentPeople;
+interface ActivityEntry {
+  id: string;
+  action: string;
+  details: string | null;
+  user_name: string | null;
+  user_email: string | null;
+  created_at: string;
+  person_id: string | null;
+  person_name: string | null;
+}
+
+interface IncompleteProfile {
+  person: Person;
+  missing_fields: string[];
+  suggestion: string;
+}
+
+interface DashboardData {
+  dashboardStats: DashboardStats;
+  recentActivity: ActivityEntry[];
+  incompleteProfiles: IncompleteProfile[];
+  recentPeople: Person[];
+}
+
+function formatAction(action: string): string {
+  const actionMap: Record<string, string> = {
+    create_person: 'Added person',
+    update_person: 'Updated person',
+    delete_person: 'Deleted person',
+    create_family: 'Created family',
+    add_source: 'Added source',
+    login: 'Logged in',
+    set_my_person: 'Linked to profile',
+  };
+  return actionMap[action] || action.replace(/_/g, ' ');
+}
+
+function formatTimeAgo(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+export default async function Home() {
+  const result = await query<DashboardData>(GET_DASHBOARD, {
+    activityLimit: 8,
+    incompleteLimit: 5,
+    recentLimit: 6,
+  });
+
+  const { dashboardStats, recentActivity, incompleteProfiles, recentPeople } =
+    result;
+
+  const generations = dashboardStats.earliest_birth
+    ? Math.ceil((new Date().getFullYear() - dashboardStats.earliest_birth) / 25)
+    : 0;
 
   return (
     <>
-      <PageHeader icon="LayoutDashboard" />
+      <PageHeader icon="LayoutDashboard" title="Dashboard" />
       <div className="content-wrapper">
-        <div className="stats-grid">
+        {/* Statistics Cards */}
+        <div className="stats-grid mb-8">
           <StatsCard
             label="Total People"
-            value={stats.total_people}
+            value={dashboardStats.total_people}
             icon="👥"
           />
           <StatsCard
             label="Families"
-            value={stats.total_families}
+            value={dashboardStats.total_families}
             icon="👨‍👩‍👧‍👦"
           />
-          <StatsCard label="Living" value={stats.living_count} icon="💚" />
           <StatsCard
-            label="Generations"
-            value={
-              stats.earliest_birth
-                ? Math.ceil(
-                    (new Date().getFullYear() - stats.earliest_birth) / 25,
-                  )
-                : 0
-            }
-            icon="🌳"
+            label="Sources"
+            value={dashboardStats.total_sources}
+            icon="📚"
           />
+          <StatsCard label="Generations" value={generations} icon="🌳" />
         </div>
 
-        <h2 className="section-title">Recently Born</h2>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+          {/* Recent Activity */}
+          <div className="card p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold flex items-center gap-2">
+                <Calendar className="w-5 h-5 text-blue-500" />
+                Recent Activity
+              </h2>
+            </div>
+            {recentActivity.length > 0 ? (
+              <div className="space-y-3">
+                {recentActivity.map((activity) => (
+                  <div
+                    key={activity.id}
+                    className="flex items-start gap-3 text-sm border-b border-gray-100 pb-3 last:border-0"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium text-gray-900">
+                        {formatAction(activity.action)}
+                        {activity.person_name && (
+                          <>
+                            {': '}
+                            {activity.person_id ? (
+                              <Link
+                                href={`/person/${activity.person_id}`}
+                                className="text-blue-600 hover:underline"
+                              >
+                                {activity.person_name}
+                              </Link>
+                            ) : (
+                              activity.person_name
+                            )}
+                          </>
+                        )}
+                      </div>
+                      <div className="text-gray-500 text-xs">
+                        {activity.user_name || activity.user_email || 'System'}{' '}
+                        • {formatTimeAgo(activity.created_at)}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-gray-500 text-sm">No recent activity</p>
+            )}
+          </div>
+
+          {/* Research Suggestions */}
+          <div className="card p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold flex items-center gap-2">
+                <BookOpen className="w-5 h-5 text-amber-500" />
+                Research Suggestions
+              </h2>
+              <Link
+                href="/research"
+                className="text-sm text-blue-600 hover:underline"
+              >
+                View all →
+              </Link>
+            </div>
+            {incompleteProfiles.length > 0 ? (
+              <div className="space-y-3">
+                {incompleteProfiles.map((item) => (
+                  <Link
+                    key={item.person.id}
+                    href={`/person/${item.person.id}`}
+                    className="block p-3 rounded-lg bg-amber-50 hover:bg-amber-100 transition-colors"
+                  >
+                    <div className="font-medium text-gray-900">
+                      {item.person.name_full}
+                    </div>
+                    <div className="text-sm text-amber-700">
+                      {item.suggestion}
+                    </div>
+                    <div className="text-xs text-gray-500 mt-1">
+                      Missing: {item.missing_fields.join(', ')}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <p className="text-gray-500 text-sm">
+                All profiles are complete! 🎉
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Quick Actions */}
+        <div className="card p-6 mb-8">
+          <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+            Quick Actions
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <ButtonLink
+              href="/tree"
+              variant="secondary"
+              className="flex flex-col items-center gap-2 py-4"
+            >
+              <TreePine className="w-6 h-6" />
+              <span>View Tree</span>
+            </ButtonLink>
+            <ButtonLink
+              href="/search"
+              variant="secondary"
+              className="flex flex-col items-center gap-2 py-4"
+            >
+              <Search className="w-6 h-6" />
+              <span>Search</span>
+            </ButtonLink>
+            <ButtonLink
+              href="/people"
+              variant="secondary"
+              className="flex flex-col items-center gap-2 py-4"
+            >
+              <Users className="w-6 h-6" />
+              <span>All People</span>
+            </ButtonLink>
+            <ButtonLink
+              href="/research"
+              variant="secondary"
+              className="flex flex-col items-center gap-2 py-4"
+            >
+              <BookOpen className="w-6 h-6" />
+              <span>Research</span>
+            </ButtonLink>
+          </div>
+        </div>
+
+        {/* Recently Added */}
+        <h2 className="section-title flex items-center gap-2">
+          <UserPlus className="w-5 h-5" />
+          Recently Born
+        </h2>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
           {recentPeople.map((person) => (
             <PersonCard key={person.id} person={person} showDetails />
           ))}
         </div>
 
+        {/* Additional Stats */}
         <div className="card p-6">
-          <h2 className="section-title">Family Overview</h2>
+          <h2 className="section-title flex items-center gap-2">
+            <GitBranch className="w-5 h-5" />
+            Family Overview
+          </h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
             <div>
-              <div className="text-2xl font-bold text-blue-600">
-                {stats.male_count}
-              </div>
-              <div className="text-sm text-gray-500">Male</div>
-            </div>
-            <div>
-              <div className="text-2xl font-bold text-pink-600">
-                {stats.female_count}
-              </div>
-              <div className="text-sm text-gray-500">Female</div>
-            </div>
-            <div>
               <div className="text-2xl font-bold text-green-600">
-                {stats.earliest_birth || '—'}
+                {dashboardStats.living_count}
+              </div>
+              <div className="text-sm text-gray-500">Living</div>
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-amber-600">
+                {dashboardStats.incomplete_count}
+              </div>
+              <div className="text-sm text-gray-500">Need Research</div>
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-purple-600">
+                {dashboardStats.earliest_birth || '—'}
               </div>
               <div className="text-sm text-gray-500">Earliest Birth</div>
             </div>
             <div>
-              <div className="text-2xl font-bold text-purple-600">
-                {stats.latest_birth || '—'}
+              <div className="text-2xl font-bold text-blue-600">
+                {dashboardStats.latest_birth || '—'}
               </div>
               <div className="text-sm text-gray-500">Latest Birth</div>
             </div>

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -423,6 +423,42 @@ export const GET_STATS = gql`
   }
 `;
 
+export const GET_DASHBOARD = gql`
+  ${PERSON_CARD_FIELDS}
+  query GetDashboard($activityLimit: Int, $incompleteLimit: Int, $recentLimit: Int) {
+    dashboardStats {
+      total_people
+      total_families
+      total_sources
+      total_media
+      earliest_birth
+      latest_birth
+      living_count
+      incomplete_count
+    }
+    recentActivity(limit: $activityLimit) {
+      id
+      action
+      details
+      user_name
+      user_email
+      created_at
+      person_id
+      person_name
+    }
+    incompleteProfiles(limit: $incompleteLimit) {
+      person {
+        ...PersonCardFields
+      }
+      missing_fields
+      suggestion
+    }
+    recentPeople(limit: $recentLimit) {
+      ...PersonCardFields
+    }
+  }
+`;
+
 export const GET_RECENT_PEOPLE = gql`
   ${PERSON_CARD_FIELDS}
   query GetRecentPeople($limit: Int) {

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -274,6 +274,35 @@ export const typeDefs = `#graphql
     birthday_reminders: Boolean!
   }
 
+  # Dashboard types
+  type ActivityEntry {
+    id: ID!
+    action: String!
+    details: String
+    user_name: String
+    user_email: String
+    created_at: String!
+    person_id: String
+    person_name: String
+  }
+
+  type IncompleteProfile {
+    person: Person!
+    missing_fields: [String!]!
+    suggestion: String!
+  }
+
+  type DashboardStats {
+    total_people: Int!
+    total_families: Int!
+    total_sources: Int!
+    total_media: Int!
+    earliest_birth: Int
+    latest_birth: Int
+    living_count: Int!
+    incomplete_count: Int!
+  }
+
   input EmailPreferencesInput {
     research_updates: Boolean
     tree_changes: Boolean
@@ -353,7 +382,12 @@ export const typeDefs = `#graphql
 
     # Stats & Research
     stats: Stats!
+    dashboardStats: DashboardStats!
     researchQueue(first: Int, after: String): PersonConnection!
+
+    # Dashboard
+    recentActivity(limit: Int): [ActivityEntry!]!
+    incompleteProfiles(limit: Int): [IncompleteProfile!]!
 
     # Ancestry traversal (optimized single query)
     ancestors(personId: ID!, generations: Int): [Person!]!


### PR DESCRIPTION
## Summary

Replaces the basic homepage with a comprehensive dashboard featuring activity tracking, research suggestions, and quick actions.

## Changes

### New GraphQL Schema
- `DashboardStats` type with sources, media, incomplete counts
- `ActivityEntry` type for audit log entries with user attribution
- `IncompleteProfile` type for research suggestions
- `dashboardStats`, `recentActivity`, `incompleteProfiles` queries

### Dashboard Features

| Widget | Description |
|--------|-------------|
| **Statistics Cards** | Total people, families, sources, generations |
| **Recent Activity** | Shows latest actions from audit_log with user names, linked to person records |
| **Research Suggestions** | Lists incomplete profiles with what's missing and actionable tips |
| **Quick Actions** | One-click buttons for Tree, Search, People, Research |
| **Family Overview** | Living count, incomplete count, earliest/latest birth years |

### Implementation
- Single `GET_DASHBOARD` query fetches all data in one request
- Activity shows formatted actions like "Added person: John Smith" with relative timestamps
- Research suggestions link directly to person pages with missing field info
- Responsive grid layout adapts to screen size

## Screenshots

The dashboard now shows:
- 4 stat cards at top
- 2-column layout with Activity and Research side by side
- Quick action buttons in a card
- Recently Born people cards
- Family Overview stats at bottom

## Testing

- [x] Lint passes
- [x] Build succeeds
- [x] Tests pass

Closes #177

