### PR TITLE
fix: Person edit crash - Select.Item empty value error

### DIFF
--- a/components/EditPersonModal.tsx
+++ b/components/EditPersonModal.tsx
@@ -36,11 +36,14 @@ export default function EditPersonModal({
   const canEdit =
     session?.user?.role === 'admin' || session?.user?.role === 'editor';
 
+  // Sentinel value for "no selection" since Radix UI Select doesn't allow empty string values
+  const SEX_UNKNOWN = 'unknown';
+
   const [formData, setFormData] = useState({
     name_full: '',
     name_given: '',
     name_surname: '',
-    sex: '',
+    sex: SEX_UNKNOWN,
     birth_date: '',
     birth_year: '',
     birth_place: '',
@@ -70,7 +73,7 @@ export default function EditPersonModal({
         name_full: person.name_full || '',
         name_given: person.name_given || '',
         name_surname: person.name_surname || '',
-        sex: person.sex || '',
+        sex: person.sex || SEX_UNKNOWN,
         birth_date: person.birth_date || '',
         birth_year: person.birth_year?.toString() || '',
         birth_place: person.birth_place || '',
@@ -122,7 +125,6 @@ export default function EditPersonModal({
     const stringFields = [
       'name_given',
       'name_surname',
-      'sex',
       'birth_date',
       'birth_place',
       'death_date',
@@ -145,6 +147,10 @@ export default function EditPersonModal({
         input[field] = value.trim() || null;
       }
     }
+
+    // Handle sex field specially - convert sentinel value back to null
+    input.sex =
+      formData.sex && formData.sex !== SEX_UNKNOWN ? formData.sex : null;
 
     // Handle year fields
     input.birth_year = formData.birth_year
@@ -215,7 +221,7 @@ export default function EditPersonModal({
                     <SelectValue placeholder="Unknown" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">Unknown</SelectItem>
+                    <SelectItem value={SEX_UNKNOWN}>Unknown</SelectItem>
                     <SelectItem value="M">Male</SelectItem>
                     <SelectItem value="F">Female</SelectItem>
                   </SelectContent>


### PR DESCRIPTION
## Summary

Fixes the person edit modal crash caused by Radix UI Select rejecting empty string values.

## Problem

When editing a person, clicking the Sex dropdown would crash with:

A Select.Item must have a value prop that is not an empty string.

Radix UI Select reserves empty string for "no selection" state and throws if any SelectItem uses it.

## Solution

Use a sentinel value pattern:
1. Define SEX_UNKNOWN = 'unknown' constant
2. Initialize form state with sentinel instead of empty string
3. Convert sentinel back to null when submitting to API
4. SelectItem uses sentinel value instead of empty string

## Changes

- components/EditPersonModal.tsx - Add sentinel value handling for Sex field

## Testing

- Lint passes
- All 167 tests pass
- Build succeeds
- Manual testing: Edit person modal opens, sex dropdown works for all states (M, F, Unknown)

Closes #211

