### PR TITLE
fix: correct GraphQL field names in ResearchPanel addSource mutation

### DIFF
--- a/__tests__/components/ResearchPanel.test.tsx
+++ b/__tests__/components/ResearchPanel.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * ResearchPanel Field Mapping Tests
+ *
+ * Tests the add note mutation field mapping to ensure correct GraphQL field names.
+ * Issue #215: https://github.com/pmilano1/kindred/issues/215
+ *
+ * The bug was that ResearchPanel was sending:
+ * - action_type instead of action
+ * - source_checked instead of source_type
+ * - external_url instead of source_url
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('ResearchPanel Field Mapping (Issue #215)', () => {
+  // Read the actual component source code to verify field names
+  const componentPath = path.join(
+    process.cwd(),
+    'components',
+    'ResearchPanel.tsx',
+  );
+  const componentSource = fs.readFileSync(componentPath, 'utf-8');
+
+  describe('handleSubmit mutation variables', () => {
+    it('uses "action" field name (not "action_type")', () => {
+      // The component should use 'action:' not 'action_type:'
+      expect(componentSource).toContain('action: actionType');
+      expect(componentSource).not.toContain('action_type: actionType');
+    });
+
+    it('uses "source_type" field name (not "source_checked")', () => {
+      // The component should use 'source_type:' not 'source_checked:'
+      expect(componentSource).toContain('source_type: sourceChecked');
+      expect(componentSource).not.toContain('source_checked: sourceChecked');
+    });
+
+    it('uses "source_url" field name (not "external_url")', () => {
+      // The component should use 'source_url:' not 'external_url:'
+      expect(componentSource).toContain('source_url: externalUrl');
+      expect(componentSource).not.toContain('external_url: externalUrl');
+    });
+
+    it('includes all required GraphQL SourceInput fields', () => {
+      // Verify the handleSubmit function includes the correct field structure
+      expect(componentSource).toMatch(
+        /input:\s*\{[^}]*action:\s*actionType[^}]*\}/s,
+      );
+      expect(componentSource).toMatch(/input:\s*\{[^}]*content[^}]*\}/s);
+      expect(componentSource).toMatch(/input:\s*\{[^}]*confidence[^}]*\}/s);
+    });
+  });
+
+  describe('GraphQL SourceInput schema alignment', () => {
+    // Read the schema to verify field names match
+    const schemaPath = path.join(process.cwd(), 'lib', 'graphql', 'schema.ts');
+    const schemaSource = fs.readFileSync(schemaPath, 'utf-8');
+
+    it('schema defines action as required field', () => {
+      expect(schemaSource).toMatch(
+        /input\s+SourceInput\s*\{[^}]*action:\s*String!/s,
+      );
+    });
+
+    it('schema defines source_type as optional field', () => {
+      expect(schemaSource).toMatch(
+        /input\s+SourceInput\s*\{[^}]*source_type:\s*String[^!]/s,
+      );
+    });
+
+    it('schema defines source_url as optional field', () => {
+      expect(schemaSource).toMatch(
+        /input\s+SourceInput\s*\{[^}]*source_url:\s*String[^!]/s,
+      );
+    });
+
+    it('schema does NOT define action_type field', () => {
+      // Ensure the wrong field names are not in schema
+      expect(schemaSource).not.toMatch(
+        /input\s+SourceInput\s*\{[^}]*action_type:/s,
+      );
+    });
+
+    it('schema does NOT define source_checked field', () => {
+      expect(schemaSource).not.toMatch(
+        /input\s+SourceInput\s*\{[^}]*source_checked:/s,
+      );
+    });
+
+    it('schema does NOT define external_url field', () => {
+      expect(schemaSource).not.toMatch(
+        /input\s+SourceInput\s*\{[^}]*external_url:/s,
+      );
+    });
+  });
+});

--- a/components/ResearchPanel.tsx
+++ b/components/ResearchPanel.tsx
@@ -210,10 +210,10 @@ export default function ResearchPanel({
       variables: {
         personId,
         input: {
-          action_type: actionType,
+          action: actionType,
           content,
-          source_checked: sourceChecked || undefined,
-          external_url: externalUrl || undefined,
+          source_type: sourceChecked || undefined,
+          source_url: externalUrl || undefined,
           confidence: confidenceField || undefined,
         },
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/bcryptjs": "^2.4.6",
         "@types/node": "^20",
         "@types/nodemailer": "^7.0.4",
@@ -6432,6 +6433,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/bcryptjs": "^2.4.6",
     "@types/node": "^20",
     "@types/nodemailer": "^7.0.4",


### PR DESCRIPTION
## Summary
Fixes the Add Note functionality in ResearchPanel which was silently failing due to incorrect GraphQL field names.

## Changes
- Fixed field name mapping in handleSubmit:
  - ction_type  ction (required by SourceInput schema)
  - source_checked  source_type
  - external_url  source_url
- Added comprehensive tests to verify field mapping matches GraphQL schema
- Added @testing-library/user-event dev dependency

## Testing
- All 10 new tests pass
- Tests verify both component field usage and schema alignment
- Lint passes

Closes #215
