### PR TITLE
feat: improve tree UI with expand bars, generation -1, and siblings

### DIFF
--- a/components/tree/FamilyTreeLazy.tsx
+++ b/components/tree/FamilyTreeLazy.tsx
@@ -18,7 +18,6 @@ import {
   DEFAULT_LAYOUT_CONFIG,
   type DescendantNode,
   type PedigreeNode,
-  type TreePerson,
   toTreePerson,
 } from './tree-types';
 import { useAncestorTree } from './useAncestorTree';


### PR DESCRIPTION
## Summary
Improves tree visualization with better expand indicators and adds generation -1 (parents) and siblings to descendant view, matching the old FamilyTree component behavior.

## Changes

### 1. **Expand Bar UI** - More visible expand indicators
- Changed from small `[+]` buttons to full-width bars underneath tiles
- Bars are 6px tall, span the full node width
- Blue bars for ancestors (▼ icon), green bars for descendants (▼ icon)
- 80% opacity for subtle appearance
- Shows loading state with gray color and `…` icon

### 2. **Generation -1 (Parents)** - Navigate up the tree in descendant view
- Fetches root person's parents via GraphQL
- Renders parents at generation -1 (above root)
- Father positioned left, mother positioned right
- Dashed stroke outlines (4,4 pattern)
- 70% opacity to distinguish from direct lineage
- Up arrow indicator (⬆) for navigation
- Proper connecting lines from root to parents

### 3. **Siblings** - Show siblings in descendant view
- Fetches root person's siblings via GraphQL
- Renders siblings at generation 0 (same level as root)
- Positioned to the left of root (father's side)
- Dashed stroke outlines (4,4 pattern)
- 70% opacity to distinguish from direct lineage
- Horizontal arrow indicator (↔) for sibling relationship
- Connecting lines to parent junction point

## Visual Design
- **Direct lineage**: Solid outlines, full opacity
- **Parents/Siblings**: Dashed outlines, 70% opacity
- **Expand bars**: Full-width colored bars below expandable nodes
- **Navigation indicators**: ⬆ for parents, ↔ for siblings

## Behavior Matches Old Component
This implementation matches the old `FamilyTree` component:
- Parents show at generation -1 in descendant view
- Siblings positioned on father's side (left)
- Dashed outlines for non-direct lineage
- Reduced opacity for visual hierarchy
- Same navigation indicators

Closes #192
Closes #213
