### PR TITLE
fix: tree expand bars not showing and excessive whitespace

### DIFF
--- a/components/tree/FamilyTreeLazy.tsx
+++ b/components/tree/FamilyTreeLazy.tsx
@@ -610,7 +610,11 @@ export function FamilyTreeLazy({
       node: DescendantNode,
       gen: number,
     ): { minX: number; maxX: number } => {
-      node.y = gen * (nodeHeight + levelGap);
+      // Add extra space at top for generation -1 (parents)
+      const topPadding = rootContext?.person?.parents?.length
+        ? nodeHeight + levelGap
+        : 0;
+      node.y = topPadding + gen * (nodeHeight + levelGap);
 
       if (node.children.length === 0) {
         const totalWidth = node.spouse ? nodeWidth * 2 + spouseGap : nodeWidth;

--- a/components/tree/useAncestorTree.ts
+++ b/components/tree/useAncestorTree.ts
@@ -68,6 +68,16 @@ const ANCESTORS_QUERY = gql`
             last_researched
             coatOfArms
           }
+          father {
+            id
+            generation
+            hasMoreAncestors
+          }
+          mother {
+            id
+            generation
+            hasMoreAncestors
+          }
         }
         mother {
           id
@@ -88,6 +98,16 @@ const ANCESTORS_QUERY = gql`
             research_priority
             last_researched
             coatOfArms
+          }
+          father {
+            id
+            generation
+            hasMoreAncestors
+          }
+          mother {
+            id
+            generation
+            hasMoreAncestors
           }
         }
       }
@@ -131,6 +151,16 @@ const ANCESTORS_QUERY = gql`
             last_researched
             coatOfArms
           }
+          father {
+            id
+            generation
+            hasMoreAncestors
+          }
+          mother {
+            id
+            generation
+            hasMoreAncestors
+          }
         }
         mother {
           id
@@ -151,6 +181,16 @@ const ANCESTORS_QUERY = gql`
             research_priority
             last_researched
             coatOfArms
+          }
+          father {
+            id
+            generation
+            hasMoreAncestors
+          }
+          mother {
+            id
+            generation
+            hasMoreAncestors
           }
         }
       }
@@ -186,12 +226,36 @@ const EXPAND_BRANCH_QUERY = gql`
         generation
         hasMoreAncestors
         person { id name_full sex birth_year death_year birth_place death_place living familysearch_id is_notable research_status research_priority last_researched coatOfArms }
+        father {
+          id
+          generation
+          hasMoreAncestors
+          person { id name_full sex birth_year death_year birth_place death_place living familysearch_id is_notable research_status research_priority last_researched coatOfArms }
+        }
+        mother {
+          id
+          generation
+          hasMoreAncestors
+          person { id name_full sex birth_year death_year birth_place death_place living familysearch_id is_notable research_status research_priority last_researched coatOfArms }
+        }
       }
       mother {
         id
         generation
         hasMoreAncestors
         person { id name_full sex birth_year death_year birth_place death_place living familysearch_id is_notable research_status research_priority last_researched coatOfArms }
+        father {
+          id
+          generation
+          hasMoreAncestors
+          person { id name_full sex birth_year death_year birth_place death_place living familysearch_id is_notable research_status research_priority last_researched coatOfArms }
+        }
+        mother {
+          id
+          generation
+          hasMoreAncestors
+          person { id name_full sex birth_year death_year birth_place death_place living familysearch_id is_notable research_status research_priority last_researched coatOfArms }
+        }
       }
     }
   }

--- a/components/tree/useDescendantTree.ts
+++ b/components/tree/useDescendantTree.ts
@@ -54,6 +54,11 @@ const DESCENDANTS_QUERY = gql`
             marriageYear
             person { ${PERSON_FIELDS} }
             spouse { ${PERSON_FIELDS} }
+            children {
+              id
+              generation
+              hasMoreDescendants
+            }
           }
         }
       }
@@ -85,6 +90,11 @@ const EXPAND_DESCENDANTS_QUERY = gql`
           marriageYear
           person { ${PERSON_FIELDS} }
           spouse { ${PERSON_FIELDS} }
+          children {
+            id
+            generation
+            hasMoreDescendants
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
Fixes two issues with the tree visualization:

1. **Expand bars not showing** - The GraphQL queries weren't fetching deep enough to get the `hasMoreAncestors`/`hasMoreDescendants` flags on leaf nodes
2. **Excessive white space at bottom** - The descendant tree SVG didn't account for generation -1 (parents) being rendered above the root

## Changes

### Ancestor Tree (`useAncestorTree.ts`)
- Extended `ANCESTORS_QUERY` to fetch generation 3 nodes with `hasMoreAncestors` flag
- Extended `EXPAND_BRANCH_QUERY` to fetch generation 2 nodes with `hasMoreAncestors` flag
- Now when you load a tree with 3 generations, the grandparents (gen 2) will show expand bars if they have parents

### Descendant Tree (`useDescendantTree.ts`)
- Extended `DESCENDANTS_QUERY` to fetch generation 4 nodes with `hasMoreDescendants` flag
- Extended `EXPAND_DESCENDANTS_QUERY` to fetch generation 3 nodes with `hasMoreDescendants` flag
- Now when you load a tree with 3 generations, the grandchildren (gen 2) will show expand bars if they have children

### Tree Visualization (`FamilyTreeLazy.tsx`)
- Added `topPadding` calculation to account for generation -1 (parents above root)
- Shifts all descendant nodes down by `nodeHeight + levelGap` when parents exist
- Eliminates excessive white space at bottom of tree

## Testing
- ✅ Lint passed
- ✅ Build succeeded
- Ready for production deployment

## Example
Before: Clicking on your grandfather's expand bar wouldn't show because the query didn't fetch deep enough to know if he has more ancestors.

After: The query fetches one generation deeper (just the `hasMoreAncestors` flag), so expand bars appear correctly on all leaf nodes.
