### PR TITLE
feat: add tree navigation icons to PersonCard and ResearchQueue

### DIFF
--- a/components/PersonCard.tsx
+++ b/components/PersonCard.tsx
@@ -1,3 +1,4 @@
+import { TreeDeciduous, Users } from 'lucide-react';
 import Link from 'next/link';
 import type { Person } from '@/lib/types';
 
@@ -85,6 +86,23 @@ export default function PersonCard({
               <CompletenessIndicator score={person.completeness_score} />
             )}
           </div>
+        </div>
+        {/* Tree navigation icons */}
+        <div className="flex gap-1 ml-2">
+          <Link
+            href={`/tree?person=${person.id}&view=ancestors`}
+            className="p-1.5 rounded hover:bg-blue-100 text-blue-600 transition-colors"
+            title="View ancestor tree"
+          >
+            <TreeDeciduous className="w-4 h-4" />
+          </Link>
+          <Link
+            href={`/tree?person=${person.id}&view=descendants`}
+            className="p-1.5 rounded hover:bg-green-100 text-green-600 transition-colors"
+            title="View descendant tree"
+          >
+            <Users className="w-4 h-4" />
+          </Link>
         </div>
       </div>
 

--- a/components/ResearchQueueClient.tsx
+++ b/components/ResearchQueueClient.tsx
@@ -2,7 +2,7 @@
 
 import { NetworkStatus } from '@apollo/client';
 import { useMutation, useQuery } from '@apollo/client/react';
-import { Loader2 } from 'lucide-react';
+import { Loader2, TreeDeciduous, Users } from 'lucide-react';
 import Link from 'next/link';
 import { useCallback } from 'react';
 import {
@@ -170,6 +170,7 @@ export default function ResearchQueueClient() {
                   <th className="py-2 px-3 text-sm font-semibold">
                     Last Researched
                   </th>
+                  <th className="py-2 px-3 text-sm font-semibold w-20">Tree</th>
                 </tr>
               </thead>
               <tbody>
@@ -262,6 +263,24 @@ export default function ResearchQueueClient() {
                               person.last_researched,
                             ).toLocaleDateString()
                           : 'Never'}
+                      </td>
+                      <td className="py-3 px-3">
+                        <div className="flex gap-1">
+                          <Link
+                            href={`/tree?person=${person.id}&view=ancestors`}
+                            className="p-1 rounded hover:bg-blue-100 text-blue-600 transition-colors"
+                            title="View ancestor tree"
+                          >
+                            <TreeDeciduous className="w-4 h-4" />
+                          </Link>
+                          <Link
+                            href={`/tree?person=${person.id}&view=descendants`}
+                            className="p-1 rounded hover:bg-green-100 text-green-600 transition-colors"
+                            title="View descendant tree"
+                          >
+                            <Users className="w-4 h-4" />
+                          </Link>
+                        </div>
                       </td>
                     </tr>
                   );


### PR DESCRIPTION
## Summary
Adds tree navigation icons to PersonCard and ResearchQueue components, providing quick access to ancestor and descendant tree views from anywhere a person is displayed.

## Changes
- **PersonCard.tsx**: Added tree navigation icons (TreeDeciduous for ancestors, Users for descendants) in the top-right corner
- **ResearchQueueClient.tsx**: Added "Tree" column with navigation icons for each person in the research queue

## UI Design
- Blue icon (TreeDeciduous) → Ancestor tree view
- Green icon (Users) → Descendant tree view
- Icons appear with hover effects (blue/green backgrounds)
- Tooltips show "View ancestor tree" / "View descendant tree"

## Impact
PersonCard is used in:
- `/people` page (person directory)
- `/search` page (search results)
- Dashboard (recent people section)

ResearchQueue is used in:
- `/research` page (research queue table)

Now users can quickly jump to tree views from any person card or research queue entry without having to visit the person detail page first.

## Testing
- ✅ Lint passed
- ✅ Build succeeded
- Ready for manual testing on production
