### PR TITLE
fix: add missing person field to generation 4 nodes in tree queries

### DIFF
--- a/components/tree/useAncestorTree.ts
+++ b/components/tree/useAncestorTree.ts
@@ -72,11 +72,43 @@ const ANCESTORS_QUERY = gql`
             id
             generation
             hasMoreAncestors
+            person {
+              id
+              name_full
+              sex
+              birth_year
+              death_year
+              birth_place
+              death_place
+              living
+              familysearch_id
+              is_notable
+              research_status
+              research_priority
+              last_researched
+              coatOfArms
+            }
           }
           mother {
             id
             generation
             hasMoreAncestors
+            person {
+              id
+              name_full
+              sex
+              birth_year
+              death_year
+              birth_place
+              death_place
+              living
+              familysearch_id
+              is_notable
+              research_status
+              research_priority
+              last_researched
+              coatOfArms
+            }
           }
         }
         mother {
@@ -155,11 +187,43 @@ const ANCESTORS_QUERY = gql`
             id
             generation
             hasMoreAncestors
+            person {
+              id
+              name_full
+              sex
+              birth_year
+              death_year
+              birth_place
+              death_place
+              living
+              familysearch_id
+              is_notable
+              research_status
+              research_priority
+              last_researched
+              coatOfArms
+            }
           }
           mother {
             id
             generation
             hasMoreAncestors
+            person {
+              id
+              name_full
+              sex
+              birth_year
+              death_year
+              birth_place
+              death_place
+              living
+              familysearch_id
+              is_notable
+              research_status
+              research_priority
+              last_researched
+              coatOfArms
+            }
           }
         }
         mother {
@@ -186,11 +250,43 @@ const ANCESTORS_QUERY = gql`
             id
             generation
             hasMoreAncestors
+            person {
+              id
+              name_full
+              sex
+              birth_year
+              death_year
+              birth_place
+              death_place
+              living
+              familysearch_id
+              is_notable
+              research_status
+              research_priority
+              last_researched
+              coatOfArms
+            }
           }
           mother {
             id
             generation
             hasMoreAncestors
+            person {
+              id
+              name_full
+              sex
+              birth_year
+              death_year
+              birth_place
+              death_place
+              living
+              familysearch_id
+              is_notable
+              research_status
+              research_priority
+              last_researched
+              coatOfArms
+            }
           }
         }
       }

--- a/components/tree/useDescendantTree.ts
+++ b/components/tree/useDescendantTree.ts
@@ -58,6 +58,9 @@ const DESCENDANTS_QUERY = gql`
               id
               generation
               hasMoreDescendants
+              marriageYear
+              person { ${PERSON_FIELDS} }
+              spouse { ${PERSON_FIELDS} }
             }
           }
         }


### PR DESCRIPTION
## Summary
**CRITICAL FIX** for production tree crash: "Cannot read properties of undefined (reading 'id')"

## Root Cause
When we extended GraphQL queries in PR #223 to fetch generation 4 nodes (to check `hasMoreAncestors`/`hasMoreDescendants` flags), we only fetched:
- `id`
- `generation`  
- `hasMoreAncestors` / `hasMoreDescendants`

But we **did NOT fetch the `person` object** for those generation 4 nodes.

The tree rendering code expects **every node to have a `person` object** with fields like `id`, `name_full`, `sex`, etc. When it tried to access `node.person.id` on generation 4 nodes, it crashed because `person` was undefined.

## Fix
Added the full `person` field (with all required fields) to generation 4 nodes in both queries:

### useAncestorTree.ts
- Added `person { id, name_full, sex, ... }` to generation 4 father/mother nodes
- Affects lines 71-112, 186-227, 249-290

### useDescendantTree.ts  
- Added `person { ... }` and `spouse { ... }` to generation 4 children nodes
- Affects lines 57-64

## Testing
- ✅ Lint passed
- ✅ Build succeeded
- Ready for immediate deployment to fix production crash

## Related
- Fixes the tree crash reported by user
- Caused by PR #223 (expand bar fix) and PR #227 (flag propagation)
- This completes the tree navigation improvements
