### PR TITLE
fix: improve expand button UI and add defensive checks

### DIFF
--- a/components/tree/FamilyTreeLazy.tsx
+++ b/components/tree/FamilyTreeLazy.tsx
@@ -115,6 +115,7 @@ export function FamilyTreeLazy({
     error: ancestorError,
     expandBranch: expandAncestorBranch,
     expandingNode: expandingAncestor,
+    expandedNodes: expandedAncestors,
   } = useAncestorTree({
     rootPersonId,
     initialGenerations: 3,
@@ -127,6 +128,7 @@ export function FamilyTreeLazy({
     error: descendantError,
     expandBranch: expandDescendantBranch,
     expandingNode: expandingDescendant,
+    expandedNodes: expandedDescendants,
   } = useDescendantTree({
     rootPersonId,
     initialGenerations: 3,
@@ -440,6 +442,10 @@ export function FamilyTreeLazy({
     // Draw nodes
     for (const node of allNodes) {
       if (node.x === undefined || node.y === undefined) continue;
+      if (!node.person) {
+        console.error('Node missing person field:', node);
+        continue;
+      }
       const person = toTreePerson(node.person);
       const isExpanding = expandingAncestor === node.id;
       const status = person.research_status || 'not_started';
@@ -549,11 +555,15 @@ export function FamilyTreeLazy({
         .attr('fill', '#6b7280')
         .text(years);
 
-      // Expand bar for nodes with more ancestors
-      if (node.hasMoreAncestors) {
+      // Expand/collapse button for nodes with more ancestors
+      const isExpanded = expandedAncestors.has(node.id);
+      const buttonHeight = 20;
+      const buttonY = nodeHeight + 4;
+
+      if (node.hasMoreAncestors || isExpanded) {
         const expandG = nodeG
           .append('g')
-          .attr('transform', `translate(0, ${nodeHeight + 2})`)
+          .attr('transform', `translate(0, ${buttonY})`)
           .style('cursor', isExpanding ? 'wait' : 'pointer')
           .on('click', (e: MouseEvent) => {
             e.stopPropagation();
@@ -562,25 +572,36 @@ export function FamilyTreeLazy({
             }
           });
 
-        // Full-width bar underneath tile
+        // Button background
         expandG
           .append('rect')
           .attr('width', nodeWidth)
-          .attr('height', 6)
-          .attr('rx', 3)
-          .attr('fill', isExpanding ? '#94a3b8' : '#3b82f6')
-          .attr('opacity', 0.8);
+          .attr('height', buttonHeight)
+          .attr('rx', 4)
+          .attr(
+            'fill',
+            isExpanding ? '#94a3b8' : isExpanded ? '#2563eb' : '#3b82f6',
+          )
+          .attr('stroke', isExpanding ? '#64748b' : '#1e40af')
+          .attr('stroke-width', 1)
+          .style('filter', 'drop-shadow(0 1px 2px rgba(0,0,0,0.1))');
 
-        // Expand icon in center of bar
+        // Button text
+        const buttonText = isExpanding
+          ? 'Loading...'
+          : isExpanded
+            ? '▲ Collapse'
+            : '▼ Load More';
+
         expandG
           .append('text')
           .attr('x', nodeWidth / 2)
-          .attr('y', 5)
+          .attr('y', buttonHeight / 2 + 4)
           .attr('text-anchor', 'middle')
-          .attr('font-size', '10px')
-          .attr('font-weight', 'bold')
+          .attr('font-size', '11px')
+          .attr('font-weight', '600')
           .attr('fill', '#fff')
-          .text(isExpanding ? '…' : '▼');
+          .text(buttonText);
       }
     }
   }, [
@@ -589,6 +610,7 @@ export function FamilyTreeLazy({
     dimensions,
     expandAncestorBranch,
     expandingAncestor,
+    expandedAncestors,
     onPersonClick,
     onTileClick,
   ]);
@@ -726,6 +748,10 @@ export function FamilyTreeLazy({
     // Draw nodes
     for (const node of allNodes) {
       if (node.x === undefined || node.y === undefined) continue;
+      if (!node.person) {
+        console.error('Node missing person field:', node);
+        continue;
+      }
       const person = toTreePerson(node.person);
       const isExpanding = expandingDescendant === node.id;
       const status = person.research_status || 'not_started';
@@ -808,11 +834,15 @@ export function FamilyTreeLazy({
         .attr('stroke', '#fff')
         .attr('stroke-width', 1);
 
-      // Expand bar for nodes with more descendants
-      if (node.hasMoreDescendants) {
+      // Expand/collapse button for nodes with more descendants
+      const isExpanded = expandedDescendants.has(node.id);
+      const buttonHeight = 20;
+      const buttonY = nodeHeight + 4;
+
+      if (node.hasMoreDescendants || isExpanded) {
         const expandG = nodeG
           .append('g')
-          .attr('transform', `translate(0, ${nodeHeight + 2})`)
+          .attr('transform', `translate(0, ${buttonY})`)
           .style('cursor', isExpanding ? 'wait' : 'pointer')
           .on('click', (e: MouseEvent) => {
             e.stopPropagation();
@@ -821,25 +851,36 @@ export function FamilyTreeLazy({
             }
           });
 
-        // Full-width bar underneath tile
+        // Button background
         expandG
           .append('rect')
           .attr('width', nodeWidth)
-          .attr('height', 6)
-          .attr('rx', 3)
-          .attr('fill', isExpanding ? '#94a3b8' : '#22c55e')
-          .attr('opacity', 0.8);
+          .attr('height', buttonHeight)
+          .attr('rx', 4)
+          .attr(
+            'fill',
+            isExpanding ? '#94a3b8' : isExpanded ? '#16a34a' : '#22c55e',
+          )
+          .attr('stroke', isExpanding ? '#64748b' : '#15803d')
+          .attr('stroke-width', 1)
+          .style('filter', 'drop-shadow(0 1px 2px rgba(0,0,0,0.1))');
 
-        // Expand icon in center of bar
+        // Button text
+        const buttonText = isExpanding
+          ? 'Loading...'
+          : isExpanded
+            ? '▲ Collapse'
+            : '▼ Load More';
+
         expandG
           .append('text')
           .attr('x', nodeWidth / 2)
-          .attr('y', 5)
+          .attr('y', buttonHeight / 2 + 4)
           .attr('text-anchor', 'middle')
-          .attr('font-size', '10px')
-          .attr('font-weight', 'bold')
+          .attr('font-size', '11px')
+          .attr('font-weight', '600')
           .attr('fill', '#fff')
-          .text(isExpanding ? '…' : '▼');
+          .text(buttonText);
       }
 
       // Draw spouse next to person
@@ -1144,6 +1185,7 @@ export function FamilyTreeLazy({
     dimensions,
     expandDescendantBranch,
     expandingDescendant,
+    expandedDescendants,
     onPersonClick,
     onTileClick,
     rootContext,

--- a/components/tree/useAncestorTree.ts
+++ b/components/tree/useAncestorTree.ts
@@ -415,11 +415,25 @@ export function useAncestorTree({
     [],
   );
 
-  // Expand a branch (fetch more ancestors for a specific person)
+  // Expand or collapse a branch (toggle)
   const expandBranch = useCallback(
     async (personId: string) => {
-      if (expandedNodes.has(personId)) return;
+      // If already expanded, collapse it
+      if (expandedNodes.has(personId)) {
+        setExpandedNodes((prev) => {
+          const next = new Set(prev);
+          next.delete(personId);
+          return next;
+        });
+        setMergedBranches((prev) => {
+          const next = new Map(prev);
+          next.delete(personId);
+          return next;
+        });
+        return;
+      }
 
+      // Otherwise, expand it
       setExpandingNode(personId);
       try {
         const result = await fetchBranch({

--- a/components/tree/useDescendantTree.ts
+++ b/components/tree/useDescendantTree.ts
@@ -160,8 +160,22 @@ export function useDescendantTree({
 
   const expandBranch = useCallback(
     async (personId: string) => {
-      if (expandedNodes.has(personId)) return;
+      // If already expanded, collapse it
+      if (expandedNodes.has(personId)) {
+        setExpandedNodes((prev) => {
+          const next = new Set(prev);
+          next.delete(personId);
+          return next;
+        });
+        setMergedBranches((prev) => {
+          const next = new Map(prev);
+          next.delete(personId);
+          return next;
+        });
+        return;
+      }
 
+      // Otherwise, expand it
       setExpandingNode(personId);
       try {
         const result = await fetchBranch({


### PR DESCRIPTION
## Summary
Fixes the tree crash and implements improved expand button UI from issue #230.

## Changes
1. **Button-style expand UI** - Replaced full-width colored bars with clear button-style UI
2. **Toggle functionality** - Expand buttons now toggle between "▼ Load More" and "▲ Collapse"
3. **Defensive checks** - Added safety checks to skip nodes without `person` field, preventing crashes

## Testing
- ✅ Tested in dev with production backend
- ✅ Expand button changes to "▲ Collapse" when clicked
- ✅ Collapse button restores original tree state
- ✅ Tree renders without crashes (skips 2 nodes with missing person data)

## Known Issues
- Two generation 3 nodes (AQ3blTMz55wG, XhPqIJPehGAv) are missing `person` field in API response
- These nodes are skipped during rendering (logged to console)
- Need to investigate why these specific nodes don't have person data

## Remaining Work (Issue #230)
- [ ] End-of-tree indicator (gray disabled button when no more ancestors/descendants)
- [ ] Optimize GraphQL queries to remove unused fields

Closes #230 (partial - core functionality complete)
