### PR TITLE
fix: add missing research weight fields to SettingsInput

### DIFF
--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -349,6 +349,13 @@ export const typeDefs = `#graphql
     show_coats_of_arms: String
     admin_email: String
     footer_text: String
+    # Research queue scoring weights (Issue #195)
+    research_weight_missing_core_dates: String
+    research_weight_missing_places: String
+    research_weight_estimated_dates: String
+    research_weight_placeholder_parent: String
+    research_weight_low_sources: String
+    research_weight_manual_priority: String
   }
 
   # ===========================================


### PR DESCRIPTION
## Summary
Fixes admin settings save failure by adding missing research weight fields to the GraphQL `SettingsInput` type.

## Problem
Admin settings page was failing to save with error:
```
Field "research_weight_estimated_dates" is not defined by type "SettingsInput"
```

## Root Cause
The GraphQL schema's `SettingsInput` type was missing 6 research weight fields that were:
- Already in the database (added by migration)
- Already in the `SiteSettings` TypeScript interface
- Already being used by the research queue scoring algorithm
- Being sent from the admin settings form

## Changes Made
Added the following fields to `SettingsInput` in `lib/graphql/schema.ts`:
- `research_weight_missing_core_dates: String`
- `research_weight_missing_places: String`
- `research_weight_estimated_dates: String`
- `research_weight_placeholder_parent: String`
- `research_weight_low_sources: String`
- `research_weight_manual_priority: String`

## Testing
✅ **Pre-PR checks:**
- `npm run lint` - ✅ Passed (zero errors, zero warnings)
- `npm test` - ✅ Passed (178/178 tests)
- `npm run build` - ✅ Successful

## Impact
- **Severity**: High - Admin could not save ANY settings changes
- **Fix**: Simple schema update, no database changes needed
- **Risk**: Low - Only adds optional fields to existing input type

Closes #234
