### PR TITLE
fix: resolve infinite scroll death loop

### DIFF
--- a/components/ResearchQueueClient.tsx
+++ b/components/ResearchQueueClient.tsx
@@ -75,7 +75,7 @@ export default function ResearchQueueClient() {
   const totalCount = data?.researchQueue.pageInfo.totalCount ?? 0;
 
   const loadMore = useCallback(() => {
-    if (!hasNextPage || !endCursor || loading) return;
+    if (!hasNextPage || !endCursor || isFetchingMore) return;
     fetchMore({
       variables: { first: PAGE_SIZE, after: endCursor },
       updateQuery: (prev, { fetchMoreResult }) => {
@@ -91,7 +91,7 @@ export default function ResearchQueueClient() {
         };
       },
     });
-  }, [hasNextPage, endCursor, loading, fetchMore]);
+  }, [hasNextPage, endCursor, isFetchingMore, fetchMore]);
 
   const { sentinelRef } = useInfiniteScroll({
     hasNextPage,

--- a/lib/hooks/useInfiniteScroll.ts
+++ b/lib/hooks/useInfiniteScroll.ts
@@ -109,7 +109,9 @@ export function useInfiniteScroll({
       observerRef.current = new IntersectionObserver(
         (entries) => {
           const [entry] = entries;
-          if (entry.isIntersecting && !loading && hasNextPage) {
+          // Only trigger if intersecting and hasNextPage
+          // Don't check loading state here to avoid dependency issues
+          if (entry.isIntersecting && hasNextPage) {
             setIsLoading(true);
             loadMoreRef.current();
           }
@@ -122,7 +124,9 @@ export function useInfiniteScroll({
 
       observerRef.current.observe(node);
     },
-    [enabled, hasNextPage, loading, threshold, scrollContainerSelector],
+    // Removed 'loading' and 'isLoading' from dependencies to prevent observer recreation
+    // The loadMoreRef callback handles the loading check
+    [enabled, hasNextPage, threshold, scrollContainerSelector],
   );
 
   // Cleanup on unmount


### PR DESCRIPTION
## Summary

Fixes the infinite scroll death loop on the research page by removing loading state from IntersectionObserver dependencies.

## Problem

The research page was entering an infinite scroll death loop, continuously triggering GraphQL requests without user interaction. This caused:
- Excessive API calls (48+ repeated requests)
- Performance degradation
- Console errors flooding

## Root Cause

The `useInfiniteScroll` hook had `loading` (and later `isLoading`) in the `sentinelRef` callback dependencies. This caused the IntersectionObserver to be recreated every time the loading state changed, which triggered the observer to fire multiple times, creating a death loop.

## Solution

Removed both `loading` and `isLoading` from the `sentinelRef` dependencies array. The `loadMore` callback already checks `isFetchingMore` before calling `fetchMore`, so the loading state check is still present but doesn't cause observer recreation.

## Changes

1. **lib/hooks/useInfiniteScroll.ts**:
   - Removed `loading` and `isLoading` from `sentinelRef` dependencies
   - Added comment explaining why loading state is not in dependencies

2. **components/ResearchQueueClient.tsx**:
   - Updated `loadMore` callback to use `isFetchingMore` instead of `loading`
   - Updated dependencies accordingly

## Testing

- ✅ Lint passed (zero warnings)
- ✅ All 178 tests passed
- ✅ Build succeeded
- ✅ Playwright testing confirmed fix:
  - Only 3 GraphQL requests total (2 initial + 1 fetchMore)
  - No repeated death loop requests
  - Infinite scroll works correctly

## Closes

Closes #248
