### PR TITLE
fix: replace empty string with UNKNOWN in sex Select to prevent crash

### DIFF
--- a/components/CreatePersonModal.tsx
+++ b/components/CreatePersonModal.tsx
@@ -37,7 +37,7 @@ export default function CreatePersonModal({
     name_full: '',
     name_given: '',
     name_surname: '',
-    sex: '',
+    sex: 'UNKNOWN',
     birth_year: '',
     birth_place: '',
     death_year: '',
@@ -67,7 +67,7 @@ export default function CreatePersonModal({
       name_full: '',
       name_given: '',
       name_surname: '',
-      sex: '',
+      sex: 'UNKNOWN',
       birth_year: '',
       birth_place: '',
       death_year: '',
@@ -95,7 +95,7 @@ export default function CreatePersonModal({
     if (formData.name_given) input.name_given = formData.name_given.trim();
     if (formData.name_surname)
       input.name_surname = formData.name_surname.trim();
-    if (formData.sex) input.sex = formData.sex;
+    if (formData.sex && formData.sex !== 'UNKNOWN') input.sex = formData.sex;
     if (formData.birth_year)
       input.birth_year = parseInt(formData.birth_year, 10);
     if (formData.birth_place) input.birth_place = formData.birth_place.trim();
@@ -206,7 +206,7 @@ export default function CreatePersonModal({
                     <SelectValue placeholder="Unknown" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">Unknown</SelectItem>
+                    <SelectItem value="UNKNOWN">Unknown</SelectItem>
                     <SelectItem value="M">Male</SelectItem>
                     <SelectItem value="F">Female</SelectItem>
                   </SelectContent>


### PR DESCRIPTION
## Summary

Fixes the JavaScript crash when rendering the CreatePersonModal by replacing the empty string value in the sex Select component with "UNKNOWN".

## Problem

Radix UI Select does not allow `<SelectItem value="">` because empty string is reserved for the "no selection" state. This caused the error:

```
Uncaught Error: A <Select.Item /> must have a value prop that is not an empty string.
```

## Solution

- Changed default `sex` value from `''` to `'UNKNOWN'`
- Updated `<SelectItem value="">` to `<SelectItem value="UNKNOWN">`
- Modified submit handler to filter out `'UNKNOWN'` (treated as null/empty when saving)

## Testing

- ✅ All lint checks pass
- ✅ All tests pass (178/178)
- ✅ Build succeeds with no TypeScript errors
- ✅ CreatePersonModal renders without errors
- ✅ Selecting "Unknown" works correctly
- ✅ Form submission handles UNKNOWN value properly (not sent to backend)

## Closes

Closes #254
