### PR TITLE
fix: add ActivityEntry type resolver to format created_at dates

### DIFF
--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -2739,4 +2739,10 @@ export const resolvers = {
         ? new Date(media.date_taken).toISOString().split('T')[0]
         : null,
   },
+
+  // ActivityEntry type resolver to properly format dates
+  ActivityEntry: {
+    created_at: (activity: { created_at: Date | string | null }) =>
+      activity.created_at ? new Date(activity.created_at).toISOString() : null,
+  },
 };


### PR DESCRIPTION
## Summary

Fixes the "Invalid Date" text appearing in the Recent Activity section on the dashboard.

## Problem

The dashboard was showing "Invalid Date" for all activity timestamps in the Recent Activity widget. This occurred because the `recentActivity` GraphQL resolver was returning raw `Date` objects from PostgreSQL without converting them to ISO strings.

## Root Cause

The `ActivityEntry` type in the GraphQL schema didn't have a type resolver to format the `created_at` field. Other types like `User`, `Invitation`, and `Media` already had type resolvers that properly convert Date objects to ISO strings, but `ActivityEntry` was missing this.

## Solution

Added an `ActivityEntry` type resolver in `lib/graphql/resolvers.ts` that:
- Converts `created_at` Date objects to ISO strings
- Handles null values gracefully
- Follows the same pattern as existing type resolvers

## Testing

- ✅ All lint checks pass
- ✅ All tests pass (178/178)
- ✅ Build succeeds with no TypeScript errors
- ✅ Dashboard now shows proper relative timestamps ("2h ago", "3d ago", etc.)

## Before/After

**Before:** "Peter Milanese • Invalid Date"
**After:** "Peter Milanese • 2h ago" (or appropriate relative time)
