### PR TITLE
feat: improve coat of arms management (Phase 1)

### DIFF
--- a/app/coats-of-arms/page.tsx
+++ b/app/coats-of-arms/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useMutation, useQuery } from '@apollo/client/react';
-import { Plus } from 'lucide-react';
+import { Plus, Users } from 'lucide-react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import { useState } from 'react';
 import LoadingSpinner from '@/components/LoadingSpinner';
@@ -20,6 +21,7 @@ interface SurnameCrest {
   description: string | null;
   origin: string | null;
   motto: string | null;
+  peopleCount: number;
 }
 
 export default function CoatsOfArmsPage() {
@@ -217,6 +219,23 @@ export default function CoatsOfArmsPage() {
                     {crest.description}
                   </p>
                 )}
+                <div className="mt-4 pt-4 border-t border-gray-200">
+                  <div className="flex items-center justify-center gap-2 text-sm text-gray-600">
+                    <Users className="w-4 h-4" />
+                    <span>
+                      {crest.peopleCount}{' '}
+                      {crest.peopleCount === 1 ? 'person' : 'people'}
+                    </span>
+                  </div>
+                  {crest.peopleCount > 0 && (
+                    <Link
+                      href={`/people?surname=${encodeURIComponent(crest.surname)}`}
+                      className="block mt-2 text-sm text-green-600 hover:underline"
+                    >
+                      View People →
+                    </Link>
+                  )}
+                </div>
                 {isEditor && (
                   <Button
                     variant="link"

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -752,6 +752,7 @@ export const GET_SURNAME_CRESTS = gql`
       origin
       motto
       created_at
+      peopleCount
     }
   }
 `;

--- a/lib/graphql/resolvers.ts
+++ b/lib/graphql/resolvers.ts
@@ -2745,4 +2745,15 @@ export const resolvers = {
     created_at: (activity: { created_at: Date | string | null }) =>
       activity.created_at ? new Date(activity.created_at).toISOString() : null,
   },
+
+  // SurnameCrest type resolver to add peopleCount field
+  SurnameCrest: {
+    peopleCount: async (crest: { surname: string }) => {
+      const { rows } = await pool.query(
+        `SELECT COUNT(*) as count FROM people WHERE LOWER(name_surname) = LOWER($1)`,
+        [crest.surname],
+      );
+      return Number.parseInt(rows[0]?.count || '0', 10);
+    },
+  },
 };

--- a/lib/graphql/schema.ts
+++ b/lib/graphql/schema.ts
@@ -158,6 +158,8 @@ export const typeDefs = `#graphql
     motto: String
     created_at: String
     updated_at: String
+    # Count of people with this surname (resolved via field resolver)
+    peopleCount: Int!
   }
 
   # ===========================================


### PR DESCRIPTION
## Summary

Improves the Coat of Arms management page with better usability and navigation features.

## Features

### 1. People Count Display
- Added `peopleCount` field to `SurnameCrest` GraphQL type
- Implemented field resolver to count people with matching surname
- Display count on each crest card with user-friendly formatting

### 2. View People Link
- Added "View People →" link on crest cards
- Links to people page filtered by surname
- Only shown when peopleCount > 0

### 3. Surname Filtering on People Page
- Added support for `?surname=X` URL query parameter
- Display active surname filter with clear button
- Client-side filtering of people by surname
- Wrapped component in Suspense boundary for useSearchParams

## Technical Details

- **GraphQL Schema**: Added `peopleCount: Int!` field to `SurnameCrest` type
- **Resolver**: Added `SurnameCrest` type resolver with `peopleCount` field
- **UI Components**: Updated `coats-of-arms/page.tsx` and `people/page.tsx`
- **Icons**: Added `Users` icon for people count, `X` icon for clear filter

## Testing

- ✅ Lint: Passed (zero warnings)
- ✅ Tests: 178/178 passed
- ✅ Build: Successful

## Implements

Phase 1 of issue #193 - Improve Coat of Arms/Crest Management

## Screenshots

(Will be added after manual testing)
