### PR TITLE
fix: email configuration check now correctly recognizes SES setup

### DIFF
--- a/lib/email.ts
+++ b/lib/email.ts
@@ -29,9 +29,10 @@ interface EmailConfig {
  */
 export function getEmailConfig(): EmailConfig {
   // Check for AWS SES configuration
+  // SES is configured if EMAIL_FROM is set to a real email (not the placeholder)
   if (
     process.env.EMAIL_FROM &&
-    process.env.EMAIL_FROM !== `${APP_NAME} <noreply@example.com>`
+    !process.env.EMAIL_FROM.includes('noreply@example.com')
   ) {
     // If EMAIL_FROM is set to a real value, assume SES is intended
     // SES will use AWS credentials from environment or IAM role


### PR DESCRIPTION
## Summary
Fixes email configuration check to correctly recognize AWS SES setup, eliminating false warnings when email is properly configured.

## Problem
The email configuration check was comparing `EMAIL_FROM` against a template string that included `APP_NAME`, which could fail if:
- `APP_NAME` environment variable wasn't set (defaults to "Kindred")
- The comparison used exact string matching instead of checking for placeholder domain

This caused false warnings showing "Email Not Configured" even when SES was properly set up with a real email address.

## Solution
Changed the validation logic to check if `EMAIL_FROM` contains the placeholder domain `noreply@example.com` instead of exact string matching. This is more robust because:
- Works regardless of `APP_NAME` setting
- Correctly identifies real email addresses vs placeholder
- Simpler and more maintainable logic

## Changes
- Updated `getEmailConfig()` in `lib/email.ts` to use `.includes('noreply@example.com')` check
- Now correctly detects SES configuration when `EMAIL_FROM` is set to a real email

## Testing
- ✅ All 178 tests passing
- ✅ Lint passing (0 errors, 0 warnings)
- ✅ Build successful
- ✅ Verified logic correctly identifies:
  - SES configured: `EMAIL_FROM="Kindred <noreply@milanese.life>"`
  - SES not configured: `EMAIL_FROM="Kindred <noreply@example.com>"`

Closes #273
