### PR TITLE
fix: restore settings form content after migration

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -165,6 +165,8 @@ export default function SettingsPage() {
     }
   };
 
+  const [refetchTrigger, setRefetchTrigger] = useState(0);
+
   const handleMigrate = async () => {
     setMigrating(true);
     try {
@@ -175,7 +177,9 @@ export default function SettingsPage() {
         type: 'success',
         text: `Migration completed: ${data.runMigrations.results.join(', ')}`,
       });
-      loadSettings();
+      await loadSettings();
+      // Trigger refetch in child components
+      setRefetchTrigger((prev) => prev + 1);
     } catch (err) {
       setMessage({
         type: 'error',
@@ -514,12 +518,12 @@ export default function SettingsPage() {
 
             {/* Email Configuration */}
             <div className="mt-8">
-              <EmailSettings />
+              <EmailSettings refetchTrigger={refetchTrigger} />
             </div>
 
             {/* Storage Configuration */}
             <div className="mt-8">
-              <StorageSettings />
+              <StorageSettings refetchTrigger={refetchTrigger} />
             </div>
 
             {/* GEDCOM Export Section */}

--- a/components/admin/EmailSettings.tsx
+++ b/components/admin/EmailSettings.tsx
@@ -66,7 +66,11 @@ interface TestEmailResult {
   };
 }
 
-export function EmailSettings() {
+interface EmailSettingsProps {
+  refetchTrigger?: number;
+}
+
+export function EmailSettings({ refetchTrigger }: EmailSettingsProps) {
   const { data, loading, refetch } =
     useQuery<EmailSettingsData>(GET_EMAIL_SETTINGS);
   const [updateSetting] = useMutation(UPDATE_SETTING);
@@ -86,6 +90,13 @@ export function EmailSettings() {
     type: 'success' | 'error';
     text: string;
   } | null>(null);
+
+  // Refetch when trigger changes (e.g., after migration)
+  useEffect(() => {
+    if (refetchTrigger !== undefined && refetchTrigger > 0) {
+      refetch();
+    }
+  }, [refetchTrigger, refetch]);
 
   // Load settings from query
   useEffect(() => {

--- a/components/admin/StorageSettings.tsx
+++ b/components/admin/StorageSettings.tsx
@@ -66,7 +66,11 @@ interface TestStorageResult {
   };
 }
 
-export function StorageSettings() {
+interface StorageSettingsProps {
+  refetchTrigger?: number;
+}
+
+export function StorageSettings({ refetchTrigger }: StorageSettingsProps) {
   const { data, loading, refetch } =
     useQuery<StorageSettingsData>(GET_STORAGE_SETTINGS);
   const [updateSetting] = useMutation(UPDATE_SETTING);
@@ -83,6 +87,13 @@ export function StorageSettings() {
     type: 'success' | 'error';
     text: string;
   } | null>(null);
+
+  // Refetch when trigger changes (e.g., after migration)
+  useEffect(() => {
+    if (refetchTrigger !== undefined && refetchTrigger > 0) {
+      refetch();
+    }
+  }, [refetchTrigger, refetch]);
 
   // Load settings from query
   useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes settings form not restoring full content after running database migration.

## Problem
After clicking "Run Migration" button in Site Settings admin page, the EmailSettings and StorageSettings components did not refetch their data, leaving the form partially empty.

## Solution
- Added `refetchTrigger` state to the settings page that increments after successful migration
- Pass the trigger as a prop to `EmailSettings` and `StorageSettings` components
- Components watch for trigger changes and refetch their Apollo queries when it updates
- Ensures all settings (email provider, storage config, etc.) display correctly after migration

## Changes
- `app/admin/settings/page.tsx`: Add refetchTrigger state and pass to child components
- `components/admin/EmailSettings.tsx`: Accept refetchTrigger prop and refetch on change
- `components/admin/StorageSettings.tsx`: Accept refetchTrigger prop and refetch on change

## Testing
- Run migration from Site Settings page
- Verify all settings (email, storage) restore and display correctly
- Verify no console errors

Closes #291
