### PR TITLE
feat: Add comments section to person profile page

### DIFF
--- a/components/CommentsSection.tsx
+++ b/components/CommentsSection.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import { useMutation, useQuery } from '@apollo/client/react';
+import { formatDistanceToNow } from 'date-fns';
+import { MessageCircle, Pencil, Reply, Send, Trash2, X } from 'lucide-react';
+import { useSession } from 'next-auth/react';
+import { useState } from 'react';
+import { Button, Textarea } from '@/components/ui';
+import {
+  ADD_COMMENT,
+  DELETE_COMMENT,
+  GET_PERSON_COMMENTS,
+  UPDATE_COMMENT,
+} from '@/lib/graphql/queries';
+import type { Comment } from '@/lib/types';
+
+interface CommentsSectionProps {
+  personId: string;
+}
+
+interface CommentItemProps {
+  comment: Comment;
+  personId: string;
+  currentUserId?: string;
+  isAdmin: boolean;
+  onReply: (parentId: string) => void;
+  replyingTo: string | null;
+  onCancelReply: () => void;
+}
+
+function CommentItem({
+  comment,
+  personId,
+  currentUserId,
+  isAdmin,
+  onReply,
+  replyingTo,
+  onCancelReply,
+}: CommentItemProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState(comment.content);
+  const [replyContent, setReplyContent] = useState('');
+
+  const [updateComment, { loading: updating }] = useMutation(UPDATE_COMMENT, {
+    refetchQueries: [{ query: GET_PERSON_COMMENTS, variables: { personId } }],
+  });
+
+  const [deleteComment, { loading: deleting }] = useMutation(DELETE_COMMENT, {
+    refetchQueries: [{ query: GET_PERSON_COMMENTS, variables: { personId } }],
+  });
+
+  const [addReply, { loading: replying }] = useMutation(ADD_COMMENT, {
+    refetchQueries: [{ query: GET_PERSON_COMMENTS, variables: { personId } }],
+  });
+
+  const canModify = currentUserId === comment.user_id || isAdmin;
+  const isReplying = replyingTo === comment.id;
+
+  const handleUpdate = async () => {
+    if (!editContent.trim()) return;
+    await updateComment({
+      variables: { id: comment.id, content: editContent },
+    });
+    setIsEditing(false);
+  };
+
+  const handleDelete = async () => {
+    if (confirm('Delete this comment?')) {
+      await deleteComment({ variables: { id: comment.id } });
+    }
+  };
+
+  const handleReply = async () => {
+    if (!replyContent.trim()) return;
+    await addReply({
+      variables: {
+        personId,
+        content: replyContent,
+        parentCommentId: comment.id,
+      },
+    });
+    setReplyContent('');
+    onCancelReply();
+  };
+
+  const userName = comment.user?.name || comment.user?.email || 'Unknown';
+  const timeAgo = formatDistanceToNow(new Date(comment.created_at), {
+    addSuffix: true,
+  });
+
+  return (
+    <div className="border-l-2 border-gray-200 pl-4 py-2">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <span className="font-medium text-gray-700">{userName}</span>
+            <span>•</span>
+            <span>{timeAgo}</span>
+            {comment.updated_at !== comment.created_at && (
+              <span className="text-xs">(edited)</span>
+            )}
+          </div>
+          {isEditing ? (
+            <div className="mt-2 space-y-2">
+              <Textarea
+                value={editContent}
+                onChange={(e) => setEditContent(e.target.value)}
+                rows={2}
+                className="w-full"
+              />
+              <div className="flex gap-2">
+                <Button size="sm" onClick={handleUpdate} disabled={updating}>
+                  Save
+                </Button>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => setIsEditing(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <p className="mt-1 text-gray-700 whitespace-pre-wrap">
+              {comment.content}
+            </p>
+          )}
+        </div>
+        {canModify && !isEditing && (
+          <div className="flex gap-1">
+            <button
+              type="button"
+              onClick={() => setIsEditing(true)}
+              className="p-1 text-gray-400 hover:text-blue-600"
+              title="Edit"
+            >
+              <Pencil className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting}
+              className="p-1 text-gray-400 hover:text-red-600"
+              title="Delete"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+      {/* Reply button */}
+      {!isEditing && !isReplying && (
+        <button
+          type="button"
+          onClick={() => onReply(comment.id)}
+          className="mt-2 flex items-center gap-1 text-sm text-gray-500 hover:text-blue-600"
+        >
+          <Reply className="w-3 h-3" />
+          Reply
+        </button>
+      )}
+      {/* Reply form */}
+      {isReplying && (
+        <div className="mt-2 space-y-2">
+          <Textarea
+            value={replyContent}
+            onChange={(e) => setReplyContent(e.target.value)}
+            placeholder="Write a reply..."
+            rows={2}
+            className="w-full"
+          />
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              onClick={handleReply}
+              disabled={replying || !replyContent.trim()}
+            >
+              <Send className="w-3 h-3 mr-1" />
+              Reply
+            </Button>
+            <Button size="sm" variant="secondary" onClick={onCancelReply}>
+              <X className="w-3 h-3 mr-1" />
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+      {/* Nested replies */}
+      {comment.replies && comment.replies.length > 0 && (
+        <div className="mt-3 ml-4 space-y-3">
+          {comment.replies.map((reply) => (
+            <CommentItem
+              key={reply.id}
+              comment={reply}
+              personId={personId}
+              currentUserId={currentUserId}
+              isAdmin={isAdmin}
+              onReply={onReply}
+              replyingTo={replyingTo}
+              onCancelReply={onCancelReply}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface CommentsData {
+  personComments: Comment[];
+}
+
+export default function CommentsSection({ personId }: CommentsSectionProps) {
+  const { data: session } = useSession();
+  const [newComment, setNewComment] = useState('');
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+
+  const { data, loading } = useQuery<CommentsData>(GET_PERSON_COMMENTS, {
+    variables: { personId },
+  });
+
+  const [addComment, { loading: adding }] = useMutation(ADD_COMMENT, {
+    refetchQueries: [{ query: GET_PERSON_COMMENTS, variables: { personId } }],
+  });
+
+  const currentUserId = session?.user?.id;
+  const isAdmin = session?.user?.role === 'admin';
+  const canComment = !!session?.user;
+
+  const handleAddComment = async () => {
+    if (!newComment.trim()) return;
+    await addComment({ variables: { personId, content: newComment } });
+    setNewComment('');
+  };
+
+  // Filter to only top-level comments (no parent)
+  const topLevelComments = (data?.personComments || []).filter(
+    (c: Comment) => !c.parent_comment_id,
+  );
+
+  return (
+    <div className="card p-6">
+      <h3 className="section-title flex items-center gap-2">
+        <MessageCircle className="w-5 h-5" />
+        Comments
+        {topLevelComments.length > 0 && (
+          <span className="text-sm font-normal text-gray-500">
+            ({topLevelComments.length})
+          </span>
+        )}
+      </h3>
+
+      {/* Add comment form */}
+      {canComment && (
+        <div className="mb-4 space-y-2">
+          <Textarea
+            value={newComment}
+            onChange={(e) => setNewComment(e.target.value)}
+            placeholder="Add a comment..."
+            rows={3}
+            className="w-full"
+          />
+          <Button
+            onClick={handleAddComment}
+            disabled={adding || !newComment.trim()}
+            size="sm"
+          >
+            <Send className="w-4 h-4 mr-1" />
+            Post Comment
+          </Button>
+        </div>
+      )}
+
+      {/* Comments list */}
+      {loading ? (
+        <p className="text-gray-500 text-sm">Loading comments...</p>
+      ) : topLevelComments.length === 0 ? (
+        <p className="text-gray-500 text-sm">
+          No comments yet.{' '}
+          {canComment ? 'Be the first to comment!' : 'Sign in to comment.'}
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {topLevelComments.map((comment: Comment) => (
+            <CommentItem
+              key={comment.id}
+              comment={comment}
+              personId={personId}
+              currentUserId={currentUserId}
+              isAdmin={isAdmin}
+              onReply={setReplyingTo}
+              replyingTo={replyingTo}
+              onCancelReply={() => setReplyingTo(null)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/PersonPageClient.tsx
+++ b/components/PersonPageClient.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import { useState } from 'react';
+import CommentsSection from '@/components/CommentsSection';
 import DeletePersonDialog from '@/components/DeletePersonDialog';
 import EditPersonModal from '@/components/EditPersonModal';
 import FactsEditor from '@/components/FactsEditor';
@@ -536,6 +537,9 @@ export default function PersonPageClient({ personId }: Props) {
               sources={person.sources || []}
               canEdit={canEdit}
             />
+
+            {/* Comments Section - Full width */}
+            <CommentsSection personId={personId} />
 
             <ButtonLink href="/people" variant="secondary" icon={ArrowLeft}>
               Back to People

--- a/lib/graphql/queries/comment.ts
+++ b/lib/graphql/queries/comment.ts
@@ -1,0 +1,71 @@
+// =====================================================
+// GraphQL Queries - Comment Operations
+// =====================================================
+// Queries and mutations for person comments (Issue #181)
+
+import { gql } from '@apollo/client';
+
+// =====================================================
+// COMMENT FRAGMENTS
+// =====================================================
+
+export const COMMENT_FIELDS = gql`
+  fragment CommentFields on Comment {
+    id
+    person_id
+    user_id
+    parent_comment_id
+    content
+    created_at
+    updated_at
+    user {
+      id
+      name
+      email
+    }
+  }
+`;
+
+// =====================================================
+// COMMENT QUERIES
+// =====================================================
+
+export const GET_PERSON_COMMENTS = gql`
+  ${COMMENT_FIELDS}
+  query GetPersonComments($personId: ID!) {
+    personComments(personId: $personId) {
+      ...CommentFields
+      replies {
+        ...CommentFields
+      }
+    }
+  }
+`;
+
+// =====================================================
+// COMMENT MUTATIONS
+// =====================================================
+
+export const ADD_COMMENT = gql`
+  ${COMMENT_FIELDS}
+  mutation AddComment($personId: ID!, $content: String!, $parentCommentId: ID) {
+    addComment(personId: $personId, content: $content, parentCommentId: $parentCommentId) {
+      ...CommentFields
+    }
+  }
+`;
+
+export const UPDATE_COMMENT = gql`
+  ${COMMENT_FIELDS}
+  mutation UpdateComment($id: ID!, $content: String!) {
+    updateComment(id: $id, content: $content) {
+      ...CommentFields
+    }
+  }
+`;
+
+export const DELETE_COMMENT = gql`
+  mutation DeleteComment($id: ID!) {
+    deleteComment(id: $id)
+  }
+`;

--- a/lib/graphql/queries/index.ts
+++ b/lib/graphql/queries/index.ts
@@ -21,6 +21,14 @@ export {
   SET_MY_PERSON,
   UPDATE_USER_ROLE,
 } from './admin';
+// Comment queries and mutations (Issue #181)
+export {
+  ADD_COMMENT,
+  COMMENT_FIELDS,
+  DELETE_COMMENT,
+  GET_PERSON_COMMENTS,
+  UPDATE_COMMENT,
+} from './comment';
 // Crest queries and mutations
 export {
   GET_SURNAME_CREST,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -206,3 +206,20 @@ export interface Media {
   uploaded_by: string | null;
   created_at: string;
 }
+
+// Comment on a person profile (Issue #181)
+export interface Comment {
+  id: string;
+  person_id: string;
+  user_id: string;
+  parent_comment_id: string | null;
+  content: string;
+  created_at: string;
+  updated_at: string;
+  user?: {
+    id: string;
+    name: string | null;
+    email: string;
+  };
+  replies?: Comment[];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "clsx": "^2.1.1",
         "d3": "^7.9.0",
         "dataloader": "^2.2.3",
+        "date-fns": "^4.1.0",
         "family-chart": "^0.9.0",
         "graphql": "^16.12.0",
         "graphql-depth-limit": "^1.1.0",
@@ -9338,6 +9339,16 @@
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.3.tgz",
       "integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "clsx": "^2.1.1",
     "d3": "^7.9.0",
     "dataloader": "^2.2.3",
+    "date-fns": "^4.1.0",
     "family-chart": "^0.9.0",
     "graphql": "^16.12.0",
     "graphql-depth-limit": "^1.1.0",


### PR DESCRIPTION
## Summary

Adds a comments section to person profile pages, enabling users to discuss and collaborate on research for each person.

## Changes

### New Components
- `CommentsSection.tsx` - Full-featured comments component with:
  - Add new comments
  - Threaded replies
  - Edit/delete own comments
  - Admin can edit/delete any comment
  - Relative timestamps (e.g., "2 hours ago")
  - User attribution

### GraphQL
- Added `lib/graphql/queries/comment.ts` with:
  - `GET_PERSON_COMMENTS` query
  - `ADD_COMMENT`, `UPDATE_COMMENT`, `DELETE_COMMENT` mutations
  - `COMMENT_FIELDS` fragment

### Types
- Added `Comment` interface to `lib/types.ts`

### Dependencies
- Added `date-fns` for relative time formatting

## Database Migration Required

The `person_comments` table needs to be created:

```sql
CREATE TABLE IF NOT EXISTS person_comments (
  id VARCHAR(12) PRIMARY KEY,
  person_id VARCHAR(100) REFERENCES people(id) ON DELETE CASCADE,
  user_id VARCHAR(100) REFERENCES users(id) ON DELETE CASCADE,
  parent_comment_id VARCHAR(12) REFERENCES person_comments(id) ON DELETE CASCADE,
  content TEXT NOT NULL,
  created_at TIMESTAMP DEFAULT NOW(),
  updated_at TIMESTAMP DEFAULT NOW()
);

CREATE INDEX IF NOT EXISTS idx_person_comments_person ON person_comments(person_id);
CREATE INDEX IF NOT EXISTS idx_person_comments_parent ON person_comments(parent_comment_id);
CREATE INDEX IF NOT EXISTS idx_person_comments_user ON person_comments(user_id);
```

## Testing
- Build passes
- All 13 test files pass
- Lint passes with zero warnings

## Closes
Closes #181
